### PR TITLE
Add support to python 3.5.* and 3.6.0 versions on tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: python
 
-python:
-  - 3.5
+matrix:
+    include:
+        - python: '3.5.0'
+        - python: '3.5.1'
+        - python: '3.5.2'
+        - python: '3.6.0'
 
 install:
   - pip install -rrequirements-test.txt

--- a/correios/utils.py
+++ b/correios/utils.py
@@ -1,5 +1,5 @@
 from itertools import chain
-from typing import Sized, Iterable, Container, Set
+from typing import Container, Iterable, Sized
 
 
 class RangeSet(Sized, Iterable, Container):
@@ -8,16 +8,21 @@ class RangeSet(Sized, Iterable, Container):
 
         for r in ranges:
             if isinstance(r, range):
-                r = [r]
-            elif isinstance(r, RangeSet):
-                r = list(r.ranges)
-            elif isinstance(r, Iterable) and not isinstance(r, Set):
-                r = [range(*r)]
-            else:
+                self.ranges.append(r)
+                continue
+
+            try:
+                element = list(r.ranges)
+            except AttributeError:
+                element = None
+
+            try:
+                element = element or [range(*r)]
+            except:
                 msg = "RangeSet argument must be a range, RangeSet or an Iterable, not {}"
                 raise ValueError(msg.format(type(r)))
 
-            self.ranges.extend(r)
+            self.ranges.extend(element)
 
     def __iter__(self):
         return chain.from_iterable(r for r in self.ranges)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,3 @@
-[tox]
-envlist=py35
-
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =


### PR DESCRIPTION
Solves #27 

- Update travis.yml to test different versions
- Fix RangeSet to work on python 3.5.0 and 3.5.1