### PR TITLE
[V2-1803] Fix posting list pdf address

### DIFF
--- a/correios/models/address.py
+++ b/correios/models/address.py
@@ -281,19 +281,14 @@ class Address:
 
     @property
     def basic_address(self):
-        number = self.number
         if self.complement:
-            number = "{} {}".format(number, self.complement)
+            number = "{} - {}".format(self.number, self.complement)
 
-        address = "{}, {}, {}".format(self.street, number, self.neighborhood)
-        if len(address) <= 60:
-            address = "{}, {}\n {}".format(self.street, number, self.neighborhood)
-
-        return capitalize_phrase(address)
+        return capitalize_phrase("{}, {}, {}".format(self.street, number, self.neighborhood))
 
     @property
     def display_address(self) -> Tuple[str, str]:
-        address = "{}, {} {}".format(self.street, self.raw_number, self.complement)
+        address = "{}, {} - {}".format(self.street, self.raw_number, self.complement)
         city = "{} / {} - {}".format(self.city, self.state, self.zip_code.display())
         return address.strip(), city.strip()
 

--- a/correios/models/address.py
+++ b/correios/models/address.py
@@ -281,8 +281,14 @@ class Address:
 
     @property
     def basic_address(self):
-        address = "{}, {}, {}, {}".format(self.street, self.number,
-                                          self.complement[:20], self.neighborhood)
+        number = self.number
+        if self.complement:
+            number = "{} {}".format(number, self.complement)
+
+        address = "{}, {}, {}".format(self.street, number, self.neighborhood)
+        if len(address) <= 60:
+            address = "{}, {}\n {}".format(self.street, number, self.neighborhood)
+
         return capitalize_phrase(address)
 
     @property

--- a/correios/models/address.py
+++ b/correios/models/address.py
@@ -22,6 +22,7 @@ from phonenumbers import PhoneNumberFormat, parse, format_number
 
 from correios.exceptions import InvalidZipCodeError, InvalidStateError
 from correios.models.data import ZIP_CODES, ZIP_CODE_MAP
+from correios.utils import capitalize_phrase
 
 ZIP_CODE_LENGTH = 8
 STATE_LENGTH = 2
@@ -280,7 +281,9 @@ class Address:
 
     @property
     def basic_address(self):
-        return "{}, {}".format(self.street, self.number)
+        address = "{}, {}, {}, {}".format(self.street, self.number,
+                                          self.complement[:20], self.neighborhood)
+        return capitalize_phrase(address)
 
     @property
     def display_address(self) -> Tuple[str, str]:

--- a/correios/models/address.py
+++ b/correios/models/address.py
@@ -16,6 +16,7 @@
 from decimal import Decimal
 import re
 from typing import List, Union, Tuple
+import warnings
 
 from phonenumbers import NumberParseException
 from phonenumbers import PhoneNumberFormat, parse, format_number
@@ -288,7 +289,10 @@ class Address:
 
     @property
     def label_address(self) -> str:
-        template = ("{address.street!s:>.40} {address.number!s:>.8}<br/>"
+        msg = "{}.label_address is going to be deprecated. Make sure you use SendAddress or ReceiverAddress"
+        warnings.warn(msg.format(type(self).__name__), DeprecationWarning)
+
+        template = ("{address.street!s:>.40} {address.number!s:>.8}<br/> "
                     "{address.complement!s:>.20} {address.neighborhood!s:>.28}")
         return capitalize_phrase(template.format(address=self))
 

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -27,7 +27,6 @@ from correios.exceptions import (InvalidAddressesError, InvalidEventStatusError,
                                  InvalidPackageSequenceError, InvalidTrackingCodeError,
                                  PostingListError, InvalidPackageDimensionsError,
                                  InvalidPackageWeightError)
-from correios.utils import rreplace
 from .address import Address, ZipCode
 from .data import SERVICE_PAC, TRACKING_EVENT_TYPES, TRACKING_STATUS
 from .user import Contract  # noqa: F401
@@ -382,11 +381,11 @@ class ShippingLabel:
     sender_header = "DESTINATÁRIO"
     carrier_logo = os.path.join(DATADIR, "carrier_logo_bw.png")
     receiver_data_template = ("{receiver.name!s:>.45}<br/>"
-                              "{basic_address!s:>.95}<br/>"
+                              "{receiver.label_address!s:>.95}<br/>"
                               "<b>{receiver.zip_code_display}</b> {receiver.city}/{receiver.state}")
 
     sender_data_template = ("<b>Remetente:</b> {sender.name}<br/>"
-                            "{basic_address!s:>.95}<br/>"
+                            "{receiver.label_address!s:>.95}<br/>"
                             "<b>{sender.zip_code_display}</b> {sender.city}-{sender.state}")
 
     def __init__(self,
@@ -492,20 +491,10 @@ class ShippingLabel:
         return self.tracking_code.splitted
 
     def get_receiver_data(self):
-        basic_address = self.receiver.basic_address
-
-        if len(basic_address) <= 55:
-            basic_address = rreplace(basic_address, ',', '<br/>', count=1)
-
-        return self.receiver_data_template.format(receiver=self.receiver, basic_address=basic_address)
+        return self.receiver_data_template.format(receiver=self.receiver)
 
     def get_sender_data(self):
-        basic_address = self.sender.basic_address
-
-        if len(basic_address) <= 65:
-            basic_address = rreplace(basic_address, ',', '<br/>', count=1)
-
-        return self.sender_data_template.format(sender=self.sender, basic_address=basic_address)
+        return self.sender_data_template.format(sender=self.sender)
 
     def _get_extra_service_info(self) -> str:
         extra_services_numbers = ["00" for _ in range(6)]

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -491,14 +491,10 @@ class ShippingLabel:
         return self.tracking_code.splitted
 
     def get_receiver_data(self):
-        data = self.receiver_data_template.format(receiver=self.receiver)
-        data = data.replace('\n', '<br/>')
-        return data
+        return self.receiver_data_template.format(receiver=self.receiver).replace('\n', '<br/>')
 
     def get_sender_data(self):
-        data = self.sender_data_template.format(sender=self.sender)
-        data = data.replace('\n', '<br/>')
-        return data
+        return self.sender_data_template.format(sender=self.sender).replace('\n', '<br/>')
 
     def _get_extra_service_info(self) -> str:
         extra_services_numbers = ["00" for _ in range(6)]

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -385,7 +385,7 @@ class ShippingLabel:
                               "<b>{receiver.zip_code_display}</b> {receiver.city}/{receiver.state}")
 
     sender_data_template = ("<b>Remetente:</b> {sender.name}<br/>"
-                            "{receiver.label_address!s:>.95}<br/>"
+                            "{sender.label_address!s:>.95}<br/>"
                             "<b>{sender.zip_code_display}</b> {sender.city}-{sender.state}")
 
     def __init__(self,

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -380,14 +380,12 @@ class ShippingLabel:
                         "Assinatura: __________________ Documento: _______________")
     sender_header = "DESTINATÁRIO"
     carrier_logo = os.path.join(DATADIR, "carrier_logo_bw.png")
-    receiver_data_template = ("{receiver.name!s:>.40}<br/>"
-                              "{receiver.basic_address!s:>.40}<br/>"
-                              "{receiver.complement!s:>.20} {receiver.neighborhood!s:>.20}<br/>"
+    receiver_data_template = ("{receiver.name!s:>.45}<br/>"
+                              "{receiver.basic_address!s:>.95}<br/>"
                               "<b>{receiver.zip_code_display}</b> {receiver.city}/{receiver.state}")
 
     sender_data_template = ("<b>Remetente:</b> {sender.name}<br/>"
-                            "{sender.basic_address!s:>.40}<br/>"
-                            "{sender.complement!s:>.20} - {sender.neighborhood!s:>.20}<br/>"
+                            "{sender.basic_address!s:>.95}<br/>"
                             "<b>{sender.zip_code_display}</b> {sender.city}-{sender.state}")
 
     def __init__(self,
@@ -493,10 +491,14 @@ class ShippingLabel:
         return self.tracking_code.splitted
 
     def get_receiver_data(self):
-        return self.receiver_data_template.format(receiver=self.receiver)
+        data = self.receiver_data_template.format(receiver=self.receiver)
+        data = data.replace('\n', '<br/>')
+        return data
 
     def get_sender_data(self):
-        return self.sender_data_template.format(sender=self.sender)
+        data = self.sender_data_template.format(sender=self.sender)
+        data = data.replace('\n', '<br/>')
+        return data
 
     def _get_extra_service_info(self) -> str:
         extra_services_numbers = ["00" for _ in range(6)]

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -27,6 +27,7 @@ from correios.exceptions import (InvalidAddressesError, InvalidEventStatusError,
                                  InvalidPackageSequenceError, InvalidTrackingCodeError,
                                  PostingListError, InvalidPackageDimensionsError,
                                  InvalidPackageWeightError)
+from correios.utils import rreplace
 from .address import Address, ZipCode
 from .data import SERVICE_PAC, TRACKING_EVENT_TYPES, TRACKING_STATUS
 from .user import Contract  # noqa: F401
@@ -381,11 +382,11 @@ class ShippingLabel:
     sender_header = "DESTINATÁRIO"
     carrier_logo = os.path.join(DATADIR, "carrier_logo_bw.png")
     receiver_data_template = ("{receiver.name!s:>.45}<br/>"
-                              "{receiver.basic_address!s:>.95}<br/>"
+                              "{basic_address!s:>.95}<br/>"
                               "<b>{receiver.zip_code_display}</b> {receiver.city}/{receiver.state}")
 
     sender_data_template = ("<b>Remetente:</b> {sender.name}<br/>"
-                            "{sender.basic_address!s:>.95}<br/>"
+                            "{basic_address!s:>.95}<br/>"
                             "<b>{sender.zip_code_display}</b> {sender.city}-{sender.state}")
 
     def __init__(self,
@@ -491,10 +492,20 @@ class ShippingLabel:
         return self.tracking_code.splitted
 
     def get_receiver_data(self):
-        return self.receiver_data_template.format(receiver=self.receiver).replace('\n', '<br/>')
+        basic_address = self.receiver.basic_address
+
+        if len(basic_address) <= 55:
+            basic_address = rreplace(basic_address, ',', '<br/>', count=1)
+
+        return self.receiver_data_template.format(receiver=self.receiver, basic_address=basic_address)
 
     def get_sender_data(self):
-        return self.sender_data_template.format(sender=self.sender).replace('\n', '<br/>')
+        basic_address = self.sender.basic_address
+
+        if len(basic_address) <= 65:
+            basic_address = rreplace(basic_address, ',', '<br/>', count=1)
+
+        return self.sender_data_template.format(sender=self.sender, basic_address=basic_address)
 
     def _get_extra_service_info(self) -> str:
         extra_services_numbers = ["00" for _ in range(6)]

--- a/correios/renderers/pdf.py
+++ b/correios/renderers/pdf.py
@@ -173,7 +173,7 @@ class ShippingLabelFlowable(Flowable):
         text_style = ParagraphStyle("text", fontName="Helvetica", fontSize=10)
         text = Paragraph(self.shipping_label.text, style=text_style)
         width = self.x2 - (self.x1 + (45 * mm))
-        text.wrap(width, 18 * mm)
+        text.wrap(width, 15 * mm)
         text.breakLines(width)
         text.drawOn(canvas, self.x1 + (45 * mm), self.y2 - (98 * mm))
 

--- a/correios/renderers/pdf.py
+++ b/correios/renderers/pdf.py
@@ -181,7 +181,7 @@ class ShippingLabelFlowable(Flowable):
         canvas.line(self.x1, self.y2 - (118 * mm), self.x2, self.y2 - (118 * mm))
         sender_style = ParagraphStyle("sender", fontName="Helvetica", fontSize=9)
         text = Paragraph(self.shipping_label.get_sender_data(), style=sender_style)
-        text.wrap(self.width, 22 * mm)
+        text.wrap(self.width - 5 * mm, 22 * mm)
         text.drawOn(canvas, self.x1 + 5 * mm, self.y1 + 2 * mm)
 
         # border

--- a/correios/renderers/pdf.py
+++ b/correios/renderers/pdf.py
@@ -161,7 +161,7 @@ class ShippingLabelFlowable(Flowable):
         # receiver
         receiver_style = ParagraphStyle("receiver", fontName="Helvetica", fontSize=10, leading=15)
         text = Paragraph(self.shipping_label.get_receiver_data(), style=receiver_style)
-        text.wrap(self.width, 22 * mm)
+        text.wrap(self.width - 5 * mm, 24 * mm)
         text.drawOn(canvas, self.x1 + 5 * mm, self.y2 - (98 * mm))
 
         # receiver zip barcode

--- a/correios/utils.py
+++ b/correios/utils.py
@@ -14,7 +14,11 @@ def rreplace(string: str, old: str, new: str, count: int = 0) -> str:
     replaced.
     """
 
-    return string[::-1].replace(old[::-1], new[::-1], count)[::-1]
+    reverse = string[::-1]
+    if count:
+        return reverse.replace(old[::-1], new[::-1], count)[::-1]
+
+    return reverse.replace(old[::-1], new[::-1])[::-1]
 
 
 class RangeSet(Sized, Iterable, Container):

--- a/correios/utils.py
+++ b/correios/utils.py
@@ -6,6 +6,17 @@ def capitalize_phrase(phrase):
     return ' '.join(word.capitalize() for word in phrase.split(' '))
 
 
+def rreplace(string, old, new, count=None):
+    """
+    Return a copy of string with all occurences of substring
+    old replace by new starting from the right. If the optional
+    argument count is given only the first count occurences are
+    replaced.
+    """
+
+    return string[::-1].replace(old[::-1], new[::-1], count)[::-1]
+
+
 class RangeSet(Sized, Iterable, Container):
     def __init__(self, *ranges):
         self.ranges = []

--- a/correios/utils.py
+++ b/correios/utils.py
@@ -2,6 +2,10 @@ from itertools import chain
 from typing import Container, Iterable, Sized
 
 
+def capitalize_phrase(phrase):
+    return ' '.join(word.capitalize() for word in phrase.split())
+
+
 class RangeSet(Sized, Iterable, Container):
     def __init__(self, *ranges):
         self.ranges = []

--- a/correios/utils.py
+++ b/correios/utils.py
@@ -3,7 +3,7 @@ from typing import Container, Iterable, Sized
 
 
 def capitalize_phrase(phrase):
-    return ' '.join(word.capitalize() for word in phrase.split())
+    return ' '.join(word.capitalize() for word in phrase.split(' '))
 
 
 class RangeSet(Sized, Iterable, Container):

--- a/correios/utils.py
+++ b/correios/utils.py
@@ -2,11 +2,11 @@ from itertools import chain
 from typing import Container, Iterable, Sized
 
 
-def capitalize_phrase(phrase):
+def capitalize_phrase(phrase: str) -> str:
     return ' '.join(word.capitalize() for word in phrase.split(' '))
 
 
-def rreplace(string, old, new, count=None):
+def rreplace(string: str, old: str, new: str, count: int = 0) -> str:
     """
     Return a copy of string with all occurences of substring
     old replace by new starting from the right. If the optional

--- a/tests/test_address_models.py
+++ b/tests/test_address_models.py
@@ -18,7 +18,8 @@ from decimal import Decimal
 import pytest
 
 from correios.exceptions import InvalidZipCodeError, InvalidStateError
-from correios.models.address import ZipCode, State, Address, Phone
+from correios.models.address import (ZipCode, State, Address, Phone, ReceiverAddress,
+                                     SenderAddress)
 
 
 def test_basic_zip():
@@ -352,7 +353,7 @@ def test_address_number_handling(raw, filtered, number, zip_complement):
     assert address.zip_complement == zip_complement
 
 
-def test_address_basic_address():
+def test_address_label_address():
     address = Address(
         name="John Doe",
         street="RUA dos Bobos",
@@ -364,15 +365,35 @@ def test_address_basic_address():
         complement="AP 01",
     )
 
-    assert '\n' in address.basic_address
-    assert 'Rua' in address.basic_address
-    assert 'Vila' in address.basic_address
-    assert '1234' in address.basic_address
-    assert 'Ap 01' in address.basic_address
+    assert 'Rua' in address.label_address
+    assert 'Vila' in address.label_address
+    assert '1234' in address.label_address
+    assert 'Ap 01' in address.label_address
 
 
-def test_address_basic_address_edge_case():
-    address = Address(
+@pytest.mark.parametrize('address_class', (ReceiverAddress, SenderAddress))
+def test_custom_address_label_address(address_class):
+    address = address_class(
+        name="John Doe",
+        street="RUA dos Bobos",
+        number="1234",
+        city="Vinicius de Moraes",
+        state="RJ",
+        zip_code="12345-678",
+        neighborhood="VILA Vileza",
+        complement="AP 01",
+    )
+
+    assert '<br/>' in address.label_address
+    assert 'Rua' in address.label_address
+    assert 'Vila' in address.label_address
+    assert '1234' in address.label_address
+    assert 'Ap 01' in address.label_address
+
+
+@pytest.mark.parametrize('address_class', (ReceiverAddress, SenderAddress))
+def test_custom_address_label_address_long_street_name(address_class):
+    address = address_class(
         name="John Doe",
         street="RUA Professor José Caetano dos Santos Mascarenhas",
         number="1234",
@@ -383,8 +404,8 @@ def test_address_basic_address_edge_case():
         complement="AP 01",
     )
 
-    assert '\n' not in address.basic_address
-    assert 'Rua' in address.basic_address
-    assert 'Vila' in address.basic_address
-    assert '1234' in address.basic_address
-    assert 'Ap 01' in address.basic_address
+    assert '<br/>' not in address.label_address
+    assert 'Rua' in address.label_address
+    assert 'Vila' in address.label_address
+    assert '1234' in address.label_address
+    assert 'Ap 01' in address.label_address

--- a/tests/test_address_models.py
+++ b/tests/test_address_models.py
@@ -14,6 +14,7 @@
 
 
 from decimal import Decimal
+import warnings
 
 import pytest
 
@@ -365,10 +366,17 @@ def test_address_label_address():
         complement="AP 01",
     )
 
-    assert 'Rua' in address.label_address
-    assert 'Vila' in address.label_address
-    assert '1234' in address.label_address
-    assert 'Ap 01' in address.label_address
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always")
+
+        assert "Rua" in address.label_address
+        assert "Vila" in address.label_address
+        assert "1234" in address.label_address
+        assert "Ap 01" in address.label_address
+
+        assert len(captured_warnings) == 4
+        assert all(w.category == DeprecationWarning for w in captured_warnings)
+        assert all("deprecated" in str(w.message) for w in captured_warnings)
 
 
 @pytest.mark.parametrize('address_class', (ReceiverAddress, SenderAddress))

--- a/tests/test_address_models.py
+++ b/tests/test_address_models.py
@@ -350,3 +350,41 @@ def test_address_number_handling(raw, filtered, number, zip_complement):
     assert address.filtered_number == filtered
     assert address.number == number
     assert address.zip_complement == zip_complement
+
+
+def test_address_basic_address():
+    address = Address(
+        name="John Doe",
+        street="RUA dos Bobos",
+        number="1234",
+        city="Vinicius de Moraes",
+        state="RJ",
+        zip_code="12345-678",
+        neighborhood="VILA Vileza",
+        complement="AP 01",
+    )
+
+    assert '\n' in address.basic_address
+    assert 'Rua' in address.basic_address
+    assert 'Vila' in address.basic_address
+    assert '1234' in address.basic_address
+    assert 'Ap 01' in address.basic_address
+
+
+def test_address_basic_address_edge_case():
+    address = Address(
+        name="John Doe",
+        street="RUA Professor José Caetano dos Santos Mascarenhas",
+        number="1234",
+        city="Vinicius de Moraes",
+        state="RJ",
+        zip_code="12345-678",
+        neighborhood="VILA Vileza",
+        complement="AP 01",
+    )
+
+    assert '\n' not in address.basic_address
+    assert 'Rua' in address.basic_address
+    assert 'Vila' in address.basic_address
+    assert '1234' in address.basic_address
+    assert 'Ap 01' in address.basic_address

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from correios.utils import capitalize_phrase, RangeSet
+from correios.utils import capitalize_phrase, RangeSet, rreplace
 
 phrase = 'FOo bAr BAZ qux'
 
@@ -48,3 +48,11 @@ def test_rangeset_iter(rangeset):
 @pytest.mark.parametrize('phrase', (phrase, phrase.upper(), phrase.lower()))
 def test_capitalize_phrase(phrase):
     assert capitalize_phrase(phrase) == 'Foo Bar Baz Qux'
+
+
+def test_rreplace():
+    phrase = 'foo bar baz qux'
+    assert rreplace(phrase, ' ', '-', 1) == 'foo bar baz-qux'
+    assert rreplace(phrase, ' ', '-', 2) == 'foo bar-baz-qux'
+    assert rreplace(phrase, ' ', '-', 3) == 'foo-bar-baz-qux'
+    assert rreplace(phrase, ' ', '-') == 'foo-bar-baz-qux'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 import pytest
 
-from correios.utils import RangeSet
+from correios.utils import capitalize_phrase, RangeSet
+
+phrase = 'FOo bAr BAZ qux'
 
 
 @pytest.fixture
@@ -41,3 +43,8 @@ def test_rangeset_does_not_contain(element, rangeset):
 
 def test_rangeset_iter(rangeset):
     assert list(rangeset) == [1, 2, 4, 5, 7, 8]
+
+
+@pytest.mark.parametrize('phrase', (phrase, phrase.upper(), phrase.lower()))
+def test_capitalize_phrase(phrase):
+    assert capitalize_phrase(phrase) == 'Foo Bar Baz Qux'


### PR DESCRIPTION
- Capitalize address so there won't be many surprises on its length
- Delegate addresses' paragraph break to reportlab (words won't be cut or split by half)
- Remove overflowing space from shipping label boxes

The generated posting list PDF have its addresses cut short. Let's take the address "RUA Professor José Caetano dos Santos Mascarenhas" for example. It is currently being rendered as:

![antes_plp](https://cloud.githubusercontent.com/assets/3208493/22075968/4986efc6-dd95-11e6-9e07-5607210e883d.png)

The generatedAfter the changes on this PR are applied:
![plp_depois](https://cloud.githubusercontent.com/assets/3208493/22076013/70298508-dd95-11e6-942e-8c613c7385fa.png)
