### PR TITLE
Capitalize names on the shipping label

### DIFF
--- a/correios/models/address.py
+++ b/correios/models/address.py
@@ -300,6 +300,10 @@ class Address:
         return capitalize_phrase(template.format(address=self))
 
     @property
+    def label_name(self) -> str:
+        return capitalize_phrase(self.name)
+
+    @property
     def display_address(self) -> Tuple[str, str]:
         address = "{}, {} - {}".format(self.street, self.raw_number, self.complement)
         city = "{} / {} - {}".format(self.city, self.state, self.zip_code.display())

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -380,11 +380,11 @@ class ShippingLabel:
                         "Assinatura: __________________ Documento: _______________")
     sender_header = "DESTINATÁRIO"
     carrier_logo = os.path.join(DATADIR, "carrier_logo_bw.png")
-    receiver_data_template = ("{receiver.name!s:>.45}<br/>"
+    receiver_data_template = ("{receiver.label_name!s:>.50}<br/>"
                               "{receiver.label_address!s:>.95}<br/>"
                               "<b>{receiver.zip_code_display}</b> {receiver.city}/{receiver.state}")
 
-    sender_data_template = ("<b>Remetente:</b> {sender.name}<br/>"
+    sender_data_template = ("<b>Remetente:</b> {sender.label_name!s:>.40}<br/>"
                             "{sender.label_address!s:>.95}<br/>"
                             "<b>{sender.zip_code_display}</b> {sender.city}-{sender.state}")
 

--- a/tests/test_address_models.py
+++ b/tests/test_address_models.py
@@ -315,7 +315,7 @@ def test_basic_address():
 
 def test_basic_address_only_mandatory_args():
     address = Address(
-        name="John Doe",
+        name="JOHN DOE",
         street="Rua dos Bobos",
         number="0",
         city="Vinicius de Moraes",
@@ -323,7 +323,7 @@ def test_basic_address_only_mandatory_args():
         zip_code="12345-678",
     )
 
-    assert address.name == "John Doe"
+    assert address.name == "JOHN DOE"
     assert address.street == "Rua dos Bobos"
     assert address.number == "0"
     assert address.city == "Vinicius de Moraes"
@@ -337,6 +337,7 @@ def test_basic_address_only_mandatory_args():
     assert address.latitude == Decimal("0.0")
     assert address.longitude == Decimal("0.0")
     assert address.basic_address == "Rua Dos Bobos, 0"
+    assert address.label_name == "John Doe"
 
 
 def test_basic_address_with_neighborhood():


### PR DESCRIPTION
Se o serumano digita o nome todo em maiúsculo o limite de caracteres dos nomes no PDF da PLP não funciona direito, vide o exemplo abaixo. Este PR corrige esse problema.

Antes do PR:
![screenshot from 2017-01-26 16-58-27](https://cloud.githubusercontent.com/assets/3208493/22345823/d36a7f24-e3e8-11e6-9806-cbb83e3a9bf8.png)

Depois:
![screenshot from 2017-01-26 17-00-04](https://cloud.githubusercontent.com/assets/3208493/22345842/e7b8b536-e3e8-11e6-84ff-a1a503d310e1.png)
