### PR TITLE
Make requirements granular and optional

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.20.2
+current_version = 1.0.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/README.rst
+++ b/README.rst
@@ -14,3 +14,14 @@ correios
    :alt: Latest Coveralls coverage status
 
 A client library for Brazilian Correios APIs (SIGEP and SRO) and services.
+
+
+Installation
+------------
+
+.. code-block::
+
+   $ pip install correios  # basic model support
+   $ pip install correios[pdf]  # label and posting list pdf generation support
+   $ pip install correios[client]  # support for SIGEP/SRO API client
+   $ pip install correios[pdf,client]  # full installation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 phonenumbers
+Pillow
 
 # pdf
 reportlab

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
-requests
-suds-jurko
 phonenumbers
+
+# pdf
 reportlab
 hubarcode
+
+# api
+requests
+suds-jurko
 lxml

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ requirements = load_requirements("requirements.txt")
 
 setup(
     name="correios",
-    version="0.20.2",
+    version="1.0.0",
     url="https://github.com/osantana/correios",
 
     author="Osvaldo Santana Neto",

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,26 @@
 from setuptools import setup, find_packages
 
 
-with open("requirements.txt") as reqs:
-    install_requires = reqs.readlines()
+def load_requirements(filename):
+    install_requires = {}
+    section = "install_requires"
 
+    reqs = open(filename)
+    for raw_line in reqs:
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        if line.startswith("#"):
+            section = line.replace("#", "").strip()
+            continue
+
+        install_requires.setdefault(section, []).append(line)
+
+    return install_requires
+
+
+requirements = load_requirements("requirements.txt")
 
 setup(
     name="correios",
@@ -32,10 +49,10 @@ setup(
     long_description=open('README.rst').read(),
 
     packages=find_packages(),
-
-    install_requires=install_requires,
-
     include_package_data=True,
+
+    install_requires=requirements.pop("install_requires"),
+    extras_requires=requirements,
 
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,11 @@ from correios.models.posting import (PostingList, Package, ShippingLabel, Tracki
                                      TrackingEvent)
 from correios.models.user import FederalTaxNumber, StateTaxNumber, Contract, PostingCard, User
 
+try:
+    from correios import client as correios
+except ImportError:
+    correios = None
+
 
 @pytest.fixture
 def valid_federal_tax_number():
@@ -191,3 +196,8 @@ class PostingListFactory(Factory):
 
 
 register(PostingListFactory, "posting_list")
+
+
+@pytest.fixture
+def client():
+    return correios.Correios(username="sigep", password="n5f9t8", environment=correios.Correios.TEST)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,7 +15,6 @@
 
 import pytest
 
-from correios.client import ModelBuilder, Correios, PostingListSerializer
 from correios.exceptions import PostingListSerializerError, TrackingCodesLimitExceededError
 from correios.models.address import ZipCode
 from correios.models.data import SERVICE_SEDEX10, SERVICE_SEDEX, EXTRA_SERVICE_VD
@@ -24,19 +23,25 @@ from correios.models.posting import (NotFoundTrackingEvent, PostingList, Shippin
 from correios.models.user import PostingCard, Service, ExtraService
 from .vcr import vcr
 
+try:
+    from correios import client as correios
+except ImportError:
+    correios = None
 
+
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
 def test_basic_client():
-    client = Correios(username="sigep", password="n5f9t8", environment=Correios.TEST)
+    client = correios.Correios(username="sigep", password="n5f9t8", environment=correios.Correios.TEST)
     assert client.sigep_url == "https://apphom.correios.com.br/SigepMasterJPA/AtendeClienteService/AtendeCliente?wsdl"
     assert not client.sigep_verify
     assert client.username == "sigep"
     assert client.password == "n5f9t8"
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
-def test_get_user():
-    client = Correios(username="sigep", password="n5f9t8", environment=Correios.TEST)
+def test_get_user(client):
     user = client.get_user(contract_number="9912208555", posting_card_number="0057018901")
 
     assert user.name == "ECT"
@@ -49,9 +54,9 @@ def test_get_user():
     assert len(contract.posting_cards) == 1
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
-def test_find_zip_code():
-    client = Correios(username="sigep", password="n5f9t8", environment=Correios.TEST)
+def test_find_zip_code(client):
     zip_address = client.find_zipcode(ZipCode("70002-900"))
 
     assert zip_address.id == 0
@@ -63,48 +68,48 @@ def test_find_zip_code():
     assert zip_address.complements == []
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
-def test_verify_service_availability(posting_card):
-    client = Correios(username="sigep", password="n5f9t8", environment=Correios.TEST)
+def test_verify_service_availability(client, posting_card):
     status = client.verify_service_availability(posting_card, SERVICE_SEDEX10, "82940150", "01310000")
-    assert status
+    assert status is True
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
-def test_get_posting_card_status(posting_card):
-    client = Correios(username="sigep", password="n5f9t8", environment=Correios.TEST)
+def test_get_posting_card_status(client, posting_card):
     status = client.get_posting_card_status(posting_card)
     assert status == PostingCard.ACTIVE
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
-def test_request_tracking_codes(user):
-    client = Correios(username="sigep", password="n5f9t8", environment=Correios.TEST)
+def test_request_tracking_codes(client, user):
     result = client.request_tracking_codes(user, Service.get(SERVICE_SEDEX), quantity=10)
     assert len(result) == 10
     assert len(result[0].code) == 13
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
-def test_generate_verification_digit():
-    client = Correios(username="sigep", password="n5f9t8", environment=Correios.TEST)
+def test_generate_verification_digit(client):
     result = client.generate_verification_digit(["DL74668653 BR"])
     assert result[0] == 6
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
-def test_close_posting_list(posting_card, posting_list: PostingList, shipping_label: ShippingLabel):
+def test_close_posting_list(client, posting_card, posting_list: PostingList, shipping_label: ShippingLabel):
     shipping_label.posting_card = posting_card
     posting_list.add_shipping_label(shipping_label)
-    client = Correios(username="sigep", password="n5f9t8", environment=Correios.TEST)
     posting_list = client.close_posting_list(posting_list, posting_card)
     assert posting_list.number is not None
     assert posting_list.closed
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
-def test_get_tracking_codes_events():
-    client = Correios(username="sigep", password="n5f9t8", environment=Correios.TEST)
+def test_get_tracking_codes_events(client):
     result = client.get_tracking_code_events(["FJ064849483BR", "DU477828695BR"])
 
     assert len(result) == 2
@@ -117,18 +122,18 @@ def test_get_tracking_codes_events():
     assert result[1].code in ("FJ064849483BR", "DU477828695BR")
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
-def test_get_tracking_code_events():
-    client = Correios(username="sigep", password="n5f9t8", environment=Correios.TEST)
+def test_get_tracking_code_events(client):
     result = client.get_tracking_code_events("FJ064849483BR")
 
     assert isinstance(result[0], TrackingCode)
     assert result[0].code == "FJ064849483BR"
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
-def test_get_tracking_code_events_withou_city_field():
-    client = Correios(username="sigep", password="n5f9t8", environment=Correios.TEST)
+def test_get_tracking_code_events_withou_city_field(client):
     result = client.get_tracking_code_events("PJ651329640BR")
 
     assert isinstance(result[0], TrackingCode)
@@ -136,20 +141,19 @@ def test_get_tracking_code_events_withou_city_field():
     assert result[0].events[0].city == ""
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
-def test_get_tracking_code_with_no_verification_digitevents():
-    client = Correios(username="sigep", password="n5f9t8", environment=Correios.TEST)
+def test_get_tracking_code_with_no_verification_digitevents(client):
     result = client.get_tracking_code_events("FJ06484948BR")
 
     assert isinstance(result[0], TrackingCode)
     assert result[0].code == "FJ064849483BR"
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
-def test_get_tracking_code_object_not_found_by_correios():
-    client = Correios(username="sigep", password="n5f9t8", environment=Correios.TEST)
+def test_get_tracking_code_object_not_found_by_correios(client):
     tracking_code = client.get_tracking_code_events("DU05508759BR")[0]
-
     assert tracking_code.events
 
     event = tracking_code.events[0]
@@ -159,22 +163,24 @@ def test_get_tracking_code_object_not_found_by_correios():
     assert event.status.status == 0
 
 
-def test_get_tracking_codes_events_over_limit():
-    client = Correios(username="sigep", password="n5f9t8", environment=Correios.TEST)
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
+def test_get_tracking_codes_events_over_limit(client):
     codes = ["DU05508759BR"] * 51
     with pytest.raises(TrackingCodesLimitExceededError):
         client.get_tracking_code_events(codes)
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 def test_builder_posting_card_status():
-    builder = ModelBuilder()
+    builder = correios.ModelBuilder()
     assert builder.build_posting_card_status("Normal") == PostingCard.ACTIVE
     assert builder.build_posting_card_status("Cancelado") == PostingCard.CANCELLED
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 def test_posting_list_serialization(posting_list, shipping_label):
     posting_list.add_shipping_label(shipping_label)
-    serializer = PostingListSerializer()
+    serializer = correios.PostingListSerializer()
     document = serializer.get_document(posting_list)
     serializer.validate(document)
     xml = serializer.get_xml(document)
@@ -183,21 +189,23 @@ def test_posting_list_serialization(posting_list, shipping_label):
     assert b"<valor_declarado>10,29</valor_declarado>" not in xml
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 def test_posting_list_serialization_with_crazy_utf8_character(posting_list, shipping_label):
     shipping_label.receiver.neighborhood = 'Olho D’Água'
     posting_list.add_shipping_label(shipping_label)
-    serializer = PostingListSerializer()
+    serializer = correios.PostingListSerializer()
     document = serializer.get_document(posting_list)
     serializer.validate(document)
     xml = serializer.get_xml(document)
     assert xml.startswith(b'<?xml version="1.0" encoding="ISO-8859-1"?><correioslog>')
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 def test_declared_value(posting_list, shipping_label):
     shipping_label.extra_services.append(ExtraService.get(EXTRA_SERVICE_VD))
     shipping_label.value = 10.29
     posting_list.add_shipping_label(shipping_label)
-    serializer = PostingListSerializer()
+    serializer = correios.PostingListSerializer()
     document = serializer.get_document(posting_list)
     serializer.validate(document)
     xml = serializer.get_xml(document)
@@ -205,26 +213,29 @@ def test_declared_value(posting_list, shipping_label):
     assert b"<valor_declarado>10,29</valor_declarado>" in xml
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 def test_fail_empty_posting_list_serialization(posting_list):
-    serializer = PostingListSerializer()
+    serializer = correios.PostingListSerializer()
     with pytest.raises(PostingListSerializerError):
         serializer.get_document(posting_list)
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 def test_fail_closed_posting_list_serialization(posting_list: PostingList, shipping_label):
     posting_list.add_shipping_label(shipping_label)
     posting_list.close_with_id(number=12345)
 
-    serializer = PostingListSerializer()
+    serializer = correios.PostingListSerializer()
     with pytest.raises(PostingListSerializerError):
         serializer.get_document(posting_list)
 
 
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
 def test_limit_size_city_name(posting_list, shipping_label):
     shipping_label.receiver.city = 'Porto Alegre (Rio Grande do Sul)'
     shipping_label.sender.city = 'Santa Maria (Rio Grande do Sul)'
     posting_list.add_shipping_label(shipping_label)
-    serializer = PostingListSerializer()
+    serializer = correios.PostingListSerializer()
     document = serializer.get_document(posting_list)
     serializer.validate(document)
     xml = serializer.get_xml(document)

--- a/tests/test_pdf_renderer.py
+++ b/tests/test_pdf_renderer.py
@@ -15,14 +15,21 @@
 
 import os
 
+import pytest
+
 from correios.models.posting import PostingList
 from correios.models.user import PostingCard
-from correios.renderers.pdf import PostingReportPDFRenderer
-from tests.conftest import ShippingLabelFactory
+from .conftest import ShippingLabelFactory
+
+try:
+    from correios.renderers.pdf import PostingReportPDFRenderer
+except ImportError:
+    PostingReportPDFRenderer = None
 
 TESTDIR = os.path.dirname(__file__)
 
 
+@pytest.mark.skipif(not PostingReportPDFRenderer, reason="PDF generation support disabled")
 def test_render_basic_shipping_label():
     shipping_labels_renderer = PostingReportPDFRenderer()
     shipping_labels = [ShippingLabelFactory.build() for _ in range(5)]
@@ -40,6 +47,7 @@ def test_render_basic_shipping_label():
     assert bytes(pdf).startswith(b"%PDF-1.4")
 
 
+@pytest.mark.skipif(not PostingReportPDFRenderer, reason="PDF generation support disabled")
 def test_render_basic_posting_list(posting_list: PostingList, posting_card: PostingCard):
     posting_list.close_with_id(number=12345)
     shipping_labels_renderer = PostingReportPDFRenderer()
@@ -51,6 +59,7 @@ def test_render_basic_posting_list(posting_list: PostingList, posting_card: Post
     assert bytes(pdf).startswith(b"%PDF-1.4")
 
 
+@pytest.mark.skipif(not PostingReportPDFRenderer, reason="PDF generation support disabled")
 def test_render_all_posting_docs(posting_list: PostingList, posting_card: PostingCard):
     posting_list.close_with_id(number=12345)
     shipping_labels_renderer = PostingReportPDFRenderer()

--- a/tests/test_xml_utils.py
+++ b/tests/test_xml_utils.py
@@ -1,6 +1,12 @@
-from correios import xml_utils
+import pytest
+
+try:
+    from correios import xml_utils
+except ImportError:
+    xml_utils = None
 
 
+@pytest.mark.skipif(not xml_utils, reason="API Client support disabled")
 def test_cdata_special_chars_handling():
     document = xml_utils.Element("test", cdata="áéíóú")
     xml = xml_utils.tostring(document, encoding="unicode").encode("iso-8859-1")


### PR DESCRIPTION
We can declare requirements like:

* `correios>=1.0.0` - only model classes and validators
* `correios[pdf]>=1.0.0` - base installation + label/posting-list pdf generation
* `correios[client]>=1.0.0` - base installation + sigep/websro api client
* `correios[client,pdf]>=1.0.0` - full installation 