### PR TITLE
Add calc prazo method to correios client

### DIFF
--- a/tests/fixtures/cassettes/test_calculate_delivery_time.yaml
+++ b/tests/fixtures/cassettes/test_calculate_delivery_time.yaml
@@ -1,0 +1,32 @@
+interactions:
+- request:
+    body: <?xml version="1.0" encoding="UTF-8"?><SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/"
+      xmlns:ns1="http://tempuri.org/"><SOAP-ENV:Header/><ns0:Body><ns1:CalcPrazo><ns1:nCdServico>04162</ns1:nCdServico><ns1:sCepOrigem>07192100</ns1:sCepOrigem><ns1:sCepDestino>80030001</ns1:sCepDestino></ns1:CalcPrazo></ns0:Body></SOAP-ENV:Envelope>
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['468']
+      Content-Type: [text/xml;charset=UTF-8]
+      SOAPAction:
+      - !!binary |
+        Imh0dHA6Ly90ZW1wdXJpLm9yZy9DYWxjUHJhem8i
+      User-Agent: [python-requests/2.13.0]
+    method: POST
+    uri: http://ws.correios.com.br/calculador/CalcPrecoPrazo.asmx
+  response:
+    body: {string: '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><CalcPrazoResponse
+        xmlns="http://tempuri.org/"><CalcPrazoResult><Servicos><cServico><Codigo>4162</Codigo><PrazoEntrega>1</PrazoEntrega><EntregaDomiciliar>S</EntregaDomiciliar><EntregaSabado>S</EntregaSabado><Erro
+        /><MsgErro /><obsFim /><DataMaxEntrega>31/07/2017</DataMaxEntrega></cServico></Servicos></CalcPrazoResult></CalcPrazoResponse></soap:Body></soap:Envelope>'}
+    headers:
+      Cache-Control: ['private, max-age=0']
+      Content-Length: ['585']
+      Content-Type: [text/xml; charset=utf-8]
+      Date: ['Fri, 28 Jul 2017 12:58:41 GMT']
+      Server: [Microsoft-IIS/7.5]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/test_calculate_delivery_time_except.yaml
+++ b/tests/fixtures/cassettes/test_calculate_delivery_time_except.yaml
@@ -1,0 +1,34 @@
+interactions:
+- request:
+    body: <?xml version="1.0" encoding="UTF-8"?><SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/"
+      xmlns:ns1="http://tempuri.org/"><SOAP-ENV:Header/><ns0:Body><ns1:CalcPrazo><ns1:nCdServico>04669</ns1:nCdServico><ns1:sCepOrigem>01311300</ns1:sCepOrigem><ns1:sCepDestino>01311300</ns1:sCepDestino></ns1:CalcPrazo></ns0:Body></SOAP-ENV:Envelope>
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['468']
+      Content-Type: [text/xml;charset=UTF-8]
+      SOAPAction:
+      - !!binary |
+        Imh0dHA6Ly90ZW1wdXJpLm9yZy9DYWxjUHJhem8i
+      User-Agent: [python-requests/2.13.0]
+    method: POST
+    uri: http://ws.correios.com.br/calculador/CalcPrecoPrazo.asmx
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"\
+        http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\
+        \ xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><CalcPrazoResponse\
+        \ xmlns=\"http://tempuri.org/\"><CalcPrazoResult><Servicos><cServico><Codigo>4669</Codigo><PrazoEntrega>0</PrazoEntrega><EntregaDomiciliar\
+        \ /><EntregaSabado /><Erro>008</Erro><MsgErro>Servi\xE7o indispon\xEDvel para\
+        \ o trecho informado.</MsgErro><obsFim /><DataMaxEntrega /></cServico></Servicos></CalcPrazoResult></CalcPrazoResponse></soap:Body></soap:Envelope>"}
+    headers:
+      Cache-Control: ['private, max-age=0']
+      Content-Length: ['589']
+      Content-Type: [text/xml; charset=utf-8]
+      Date: ['Fri, 28 Jul 2017 13:09:43 GMT']
+      Server: [Microsoft-IIS/7.5]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -304,3 +304,19 @@ def test_calculate_freight_with_error(client, posting_card, package: Package):
     assert len(freights) == 1
     assert freights[0].error_code == -4
     assert freights[0].error_message == "Peso excedido."
+
+
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
+@vcr.use_cassette
+def test_calculate_delivery_time(client):
+    expected_delivery_time = 1
+    delivery_time = client.calculate_delivery_time(Service.get(SERVICE_SEDEX), '07192100', '80030001')
+    assert expected_delivery_time == int(delivery_time)
+
+
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
+@vcr.use_cassette
+def test_calculate_delivery_time_service_not_allowed_for_path(client):
+    expected_delivery_time = 0
+    delivery_time = client.calculate_delivery_time(Service.get(SERVICE_PAC), '01311300', '01311300')
+    assert expected_delivery_time == int(delivery_time)


### PR DESCRIPTION
In order to get delivery time estimation from Correios web services, I'm opening this pull request to add CalcPrazo operation[1].

I had to change the freight SoapClient instantiation adding `NoCache` because the tests were not passing[2]. According what I saw, suds lib uses schema cache and calling two different operations from suds Client (wsdl) makes it do not find proper data schema.

[1] - http://ws.correios.com.br/calculador/CalcPrecoPrazo.asmx?op=CalcPrazo
[2] - https://travis-ci.org/olist/correios/jobs/257902922