### PR TITLE
fix wsdl load after project update

### DIFF
--- a/correios/utils.py
+++ b/correios/utils.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import re
 from datetime import datetime
 from decimal import Decimal
 from itertools import chain
 from typing import Container, Iterable, Sized, Union
+
+import pkg_resources
 
 
 def capitalize_phrase(phrase: str) -> str:
@@ -98,6 +99,7 @@ def to_decimal(value: Union[Decimal, str, float], precision=2):
 
 
 def get_wsdl_path(filename) -> str:
-    return os.path.abspath(
-        'correios/wsdls/{}'.format(filename)
-    )
+    resource_package = 'correios'
+    resource_path = '/'.join(('wsdls', filename))
+
+    return pkg_resources.resource_filename(resource_package, resource_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from unittest import mock
 
 import pytest
 
@@ -102,3 +103,13 @@ def test_get_wsdl_file_path():
     filepath = get_wsdl_path('fake')
 
     assert 'correios/wsdls/fake' in filepath
+
+
+def test_should_use_pkg_resources_to_get_wsdl_files():
+    """
+    The wsdl files should be load from installed packages
+    """
+    with mock.patch('pkg_resources.resource_filename') as mock_resouce:
+        get_wsdl_path('fake')
+
+    mock_resouce.assert_called_with('correios', 'wsdls/fake')


### PR DESCRIPTION
`3.1.0` broke because client try to load wsdl file from project who was installed.