### PR TITLE
Set default freight values in case of error.

### DIFF
--- a/correios/client.py
+++ b/correios/client.py
@@ -27,7 +27,6 @@ from .models.address import ZipAddress, ZipCode
 from .models.posting import (
     EventStatus,
     Freight,
-    FreightError,
     NotFoundTrackingEvent,
     Package,
     PostingList,
@@ -169,30 +168,27 @@ class ModelBuilder:
         for service_data in response.cServico:
             service = Service.get(service_data.Codigo)
             error_code = to_integer(service_data.Erro)
-            if error_code:
-                freight = FreightError(
-                    service=service,
-                    error_code=error_code,
-                    error_message=service_data.MsgErro,
-                )
-            else:
-                delivery_time = int(service_data.PrazoEntrega)
-                value = to_decimal(service_data.ValorSemAdicionais)
-                declared_value = to_decimal(service_data.ValorValorDeclarado)
-                ar_value = to_decimal(service_data.ValorAvisoRecebimento)
-                mp_value = to_decimal(service_data.ValorMaoPropria)
-                saturday = service_data.EntregaSabado or ""
-                home = service_data.EntregaDomiciliar or ""
-                freight = Freight(
-                    service=service,
-                    delivery_time=delivery_time,
-                    value=value,
-                    declared_value=declared_value,
-                    ar_value=ar_value,
-                    mp_value=mp_value,
-                    saturday=saturday.upper() == "S",
-                    home=home.upper() == "S",
-                )
+            delivery_time = int(service_data.PrazoEntrega)
+            value = to_decimal(service_data.ValorSemAdicionais)
+            declared_value = to_decimal(service_data.ValorValorDeclarado)
+            ar_value = to_decimal(service_data.ValorAvisoRecebimento)
+            mp_value = to_decimal(service_data.ValorMaoPropria)
+            saturday = service_data.EntregaSabado or ""
+            home = service_data.EntregaDomiciliar or ""
+            error_message = service_data.MsgErro or None
+
+            freight = Freight(
+                service=service,
+                delivery_time=delivery_time,
+                value=value,
+                declared_value=declared_value,
+                ar_value=ar_value,
+                mp_value=mp_value,
+                saturday=saturday.upper() == "S",
+                home=home.upper() == "S",
+                error_code=error_code,
+                error_message=error_message,
+            )
             result.append(freight)
         return result
 

--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -1863,9 +1863,3 @@ ZIP_CODE_MAP = {
 }  # type: Dict[str, Tuple[RangeSet, RangeSet]]
 
 ZIP_CODES = RangeSet(*(p[0] for p in ZIP_CODE_MAP.values()))
-
-
-# Status Code Restriction Zip
-INITIAL_ZIPCODE_RESTRICTED = 9
-FINAL_ZIPCODE_RESTRICTED = 10
-INITIAL_AND_FINAL_ZIPCODE_RESTRICTED = 11

--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -1863,3 +1863,9 @@ ZIP_CODE_MAP = {
 }  # type: Dict[str, Tuple[RangeSet, RangeSet]]
 
 ZIP_CODES = RangeSet(*(p[0] for p in ZIP_CODE_MAP.values()))
+
+
+# Status Code Restriction Zip
+INITIAL_ZIPCODE_RESTRICTED = 9
+FINAL_ZIPCODE_RESTRICTED = 10
+INITIAL_AND_FINAL_ZIPCODE_RESTRICTED = 11

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -696,7 +696,9 @@ class Freight:
                  mp_value: Union[Decimal, float, int, str] = 0.00,
                  ar_value: Union[Decimal, float, int, str] = 0.00,
                  saturday: bool = False,
-                 home: bool = False) -> None:
+                 home: bool = False,
+                 error_code: Union[int, str] = 0,
+                 error_message: str = None) -> None:
 
         self.service = Service.get(service)
 
@@ -722,19 +724,9 @@ class Freight:
 
         self.saturday = saturday
         self.home = home
-        self.error_code = 0
-        self.error_message = ""
+        self.error_code = error_code
+        self.error_message = error_message
 
     @property
     def total(self):
         return self.value + self.declared_value + self.ar_value + self.mp_value
-
-
-class FreightError(Freight):
-    def __init__(self,
-                 service: Union[Service, int],
-                 error_code: Union[str, int],
-                 error_message: str) -> None:
-        super().__init__(service=service, delivery_time=0, value=Decimal("0.00"))
-        self.error_code = int(error_code)
-        self.error_message = error_message

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -722,11 +722,21 @@ class Freight:
             ar_value = to_decimal(ar_value)
         self.ar_value = ar_value
 
+        if not isinstance(saturday, bool):
+            saturday = (saturday == 'S')
         self.saturday = saturday
+
+        if not isinstance(home, bool):
+            home = (home == 'S')
         self.home = home
+
         self.error_code = error_code
         self.error_message = error_message
 
     @property
     def total(self):
         return self.value + self.declared_value + self.ar_value + self.mp_value
+
+
+class FreightError(Freight):
+    pass

--- a/correios/utils.py
+++ b/correios/utils.py
@@ -56,7 +56,7 @@ class RangeSet(Sized, Iterable, Container):
 
             try:
                 element = element or [range(*r)]
-            except:
+            except Exception:
                 msg = "RangeSet argument must be a range, RangeSet or an Iterable, not {}"
                 raise ValueError(msg.format(type(r)))
 

--- a/tests/fixtures/cassettes/test_calculate_freight_with_error_code_10_restricted.yaml
+++ b/tests/fixtures/cassettes/test_calculate_freight_with_error_code_10_restricted.yaml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:CalcPrecoPrazo
+      xmlns:ns0="http://tempuri.org/"><ns0:nCdEmpresa>08888888</ns0:nCdEmpresa><ns0:sDsSenha>XXXXXX</ns0:sDsSenha><ns0:nCdServico>40010</ns0:nCdServico><ns0:sCepOrigem>07192100</ns0:sCepOrigem><ns0:sCepDestino>09960610</ns0:sCepDestino><ns0:nVlPeso>7.6</ns0:nVlPeso><ns0:nCdFormato>2</ns0:nCdFormato><ns0:nVlComprimento>26</ns0:nVlComprimento><ns0:nVlAltura>3</ns0:nVlAltura><ns0:nVlLargura>14</ns0:nVlLargura><ns0:nVlDiametro>16</ns0:nVlDiametro><ns0:sCdMaoPropria>S</ns0:sCdMaoPropria><ns0:nVlValorDeclarado>9000.00</ns0:nVlValorDeclarado><ns0:sCdAvisoRecebimento>S</ns0:sCdAvisoRecebimento></ns0:CalcPrecoPrazo></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['796']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://tempuri.org/CalcPrecoPrazo"']
+      User-Agent: [Zeep/2.4.0 (www.python-zeep.org)]
+    method: POST
+    uri: http://ws.correios.com.br/calculador/CalcPrecoPrazo.asmx
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><CalcPrecoPrazoResponse
+        xmlns=\"http://tempuri.org/\"><CalcPrecoPrazoResult><Servicos><cServico><Codigo>40010</Codigo><Valor>175,05</Valor><PrazoEntrega>2</PrazoEntrega><ValorMaoPropria>5,90</ValorMaoPropria><ValorAvisoRecebimento>5,00</ValorAvisoRecebimento><ValorValorDeclarado>134,25</ValorValorDeclarado><EntregaDomiciliar>N</EntregaDomiciliar><EntregaSabado>S</EntregaSabado><Erro>010</Erro><MsgErro>O
+        CEP de destino est\xE1 temporariamente sem entrega domiciliar. A entrega ser\xE1
+        efetuada na ag\xEAncia indicada no Aviso de Chegada que ser\xE1 entregue no
+        endere\xE7o do destinat\xE1rio.</MsgErro><ValorSemAdicionais>29,90</ValorSemAdicionais><obsFim>O
+        CEP de destino est\xE1 temporariamente sem entrega domiciliar. A entrega ser\xE1
+        efetuada na ag\xEAncia indicada no Aviso de Chegada que ser\xE1 entregue no
+        endere\xE7o do destinat\xE1rio.</obsFim></cServico></Servicos></CalcPrecoPrazoResult></CalcPrecoPrazoResponse></soap:Body></soap:Envelope>"}
+    headers:
+      Cache-Control: ['private, max-age=0']
+      Content-Length: ['1148']
+      Content-Type: [text/xml; charset=utf-8]
+      Date: ['Fri, 20 Oct 2017 12:26:32 GMT']
+      Server: [Microsoft-IIS/7.5]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/test_calculate_freight_with_error_code_11_restricted.yaml
+++ b/tests/fixtures/cassettes/test_calculate_freight_with_error_code_11_restricted.yaml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:CalcPrecoPrazo
+      xmlns:ns0="http://tempuri.org/"><ns0:nCdEmpresa>08888888</ns0:nCdEmpresa><ns0:sDsSenha>XXXXXX</ns0:sDsSenha><ns0:nCdServico>40010</ns0:nCdServico><ns0:sCepOrigem>09960610</ns0:sCepOrigem><ns0:sCepDestino>04475490</ns0:sCepDestino><ns0:nVlPeso>7.5</ns0:nVlPeso><ns0:nCdFormato>2</ns0:nCdFormato><ns0:nVlComprimento>24</ns0:nVlComprimento><ns0:nVlAltura>27</ns0:nVlAltura><ns0:nVlLargura>15</ns0:nVlLargura><ns0:nVlDiametro>16</ns0:nVlDiametro><ns0:sCdMaoPropria>S</ns0:sCdMaoPropria><ns0:nVlValorDeclarado>9000.00</ns0:nVlValorDeclarado><ns0:sCdAvisoRecebimento>S</ns0:sCdAvisoRecebimento></ns0:CalcPrecoPrazo></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['797']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://tempuri.org/CalcPrecoPrazo"']
+      User-Agent: [Zeep/2.4.0 (www.python-zeep.org)]
+    method: POST
+    uri: http://ws.correios.com.br/calculador/CalcPrecoPrazo.asmx
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><CalcPrecoPrazoResponse
+        xmlns=\"http://tempuri.org/\"><CalcPrecoPrazoResult><Servicos><cServico><Codigo>40010</Codigo><Valor>175,05</Valor><PrazoEntrega>8</PrazoEntrega><ValorMaoPropria>5,90</ValorMaoPropria><ValorAvisoRecebimento>5,00</ValorAvisoRecebimento><ValorValorDeclarado>134,25</ValorValorDeclarado><EntregaDomiciliar>S</EntregaDomiciliar><EntregaSabado>S</EntregaSabado><Erro>011</Erro><MsgErro>O
+        CEP de destino est\xE1 sujeito a condi\xE7\xF5es especiais de entrega  pela
+        \ ECT e ser\xE1 realizada com o acr\xE9scimo de at\xE9 7 (sete) dias \xFAteis
+        ao prazo regular.</MsgErro><ValorSemAdicionais>29,90</ValorSemAdicionais><obsFim>O
+        CEP de destino est\xE1 sujeito a condi\xE7\xF5es especiais de entrega  pela
+        \ ECT e ser\xE1 realizada com o acr\xE9scimo de at\xE9 7 (sete) dias \xFAteis
+        ao prazo regular.</obsFim></cServico></Servicos></CalcPrecoPrazoResult></CalcPrecoPrazoResponse></soap:Body></soap:Envelope>"}
+    headers:
+      Cache-Control: ['private, max-age=0']
+      Content-Length: ['1108']
+      Content-Type: [text/xml; charset=utf-8]
+      Date: ['Fri, 20 Oct 2017 12:26:32 GMT']
+      Server: [Microsoft-IIS/7.5]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/cassettes/test_calculate_freight_with_error_code_9_restricted.yaml
+++ b/tests/fixtures/cassettes/test_calculate_freight_with_error_code_9_restricted.yaml
@@ -1,0 +1,36 @@
+interactions:
+- request:
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:CalcPrecoPrazo
+      xmlns:ns0="http://tempuri.org/"><ns0:nCdEmpresa>08888888</ns0:nCdEmpresa><ns0:sDsSenha>XXXXXX</ns0:sDsSenha><ns0:nCdServico>40010</ns0:nCdServico><ns0:sCepOrigem>09960610</ns0:sCepOrigem><ns0:sCepDestino>04475490</ns0:sCepDestino><ns0:nVlPeso>2.6</ns0:nVlPeso><ns0:nCdFormato>2</ns0:nCdFormato><ns0:nVlComprimento>22</ns0:nVlComprimento><ns0:nVlAltura>12</ns0:nVlAltura><ns0:nVlLargura>17</ns0:nVlLargura><ns0:nVlDiametro>16</ns0:nVlDiametro><ns0:sCdMaoPropria>S</ns0:sCdMaoPropria><ns0:nVlValorDeclarado>9000.00</ns0:nVlValorDeclarado><ns0:sCdAvisoRecebimento>S</ns0:sCdAvisoRecebimento></ns0:CalcPrecoPrazo></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['797']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['"http://tempuri.org/CalcPrecoPrazo"']
+      User-Agent: [Zeep/2.4.0 (www.python-zeep.org)]
+    method: POST
+    uri: http://ws.correios.com.br/calculador/CalcPrecoPrazo.asmx
+  response:
+    body: {string: "<?xml version=\"1.0\" encoding=\"utf-8\"?><soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\"
+        xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><soap:Body><CalcPrecoPrazoResponse
+        xmlns=\"http://tempuri.org/\"><CalcPrecoPrazoResult><Servicos><cServico><Codigo>40010</Codigo><Valor>165,95</Valor><PrazoEntrega>8</PrazoEntrega><ValorMaoPropria>5,90</ValorMaoPropria><ValorAvisoRecebimento>5,00</ValorAvisoRecebimento><ValorValorDeclarado>134,25</ValorValorDeclarado><EntregaDomiciliar>S</EntregaDomiciliar><EntregaSabado>S</EntregaSabado><Erro>09</Erro><MsgErro>O
+        CEP de destino est\xE1 sujeito a condi\xE7\xF5es especiais de entrega  pela
+        \ ECT e ser\xE1 realizada com o acr\xE9scimo de at\xE9 7 (sete) dias \xFAteis
+        ao prazo regular.</MsgErro><ValorSemAdicionais>20,80</ValorSemAdicionais><obsFim>O
+        CEP de destino est\xE1 sujeito a condi\xE7\xF5es especiais de entrega  pela
+        \ ECT e ser\xE1 realizada com o acr\xE9scimo de at\xE9 7 (sete) dias \xFAteis
+        ao prazo regular.</obsFim></cServico></Servicos></CalcPrecoPrazoResult></CalcPrecoPrazoResponse></soap:Body></soap:Envelope>"}
+    headers:
+      Cache-Control: ['private, max-age=0']
+      Content-Length: ['1108']
+      Content-Type: [text/xml; charset=utf-8]
+      Date: ['Fri, 20 Oct 2017 18:13:55 GMT']
+      Server: [Microsoft-IIS/7.5]
+      X-AspNet-Version: [4.0.30319]
+      X-Powered-By: [ASP.NET]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,20 +17,18 @@ from decimal import Decimal
 
 import pytest
 
+from correios.client import ValidRestrictResponse
 from correios.exceptions import PostingListSerializerError, TrackingCodesLimitExceededError
 from correios.models.address import ZipCode
 from correios.models.data import (
     EXTRA_SERVICE_AR,
     EXTRA_SERVICE_MP,
     EXTRA_SERVICE_VD,
-    FINAL_ZIPCODE_RESTRICTED,
-    INITIAL_AND_FINAL_ZIPCODE_RESTRICTED,
-    INITIAL_ZIPCODE_RESTRICTED,
     SERVICE_PAC,
     SERVICE_SEDEX,
     SERVICE_SEDEX10
 )
-from correios.models.posting import NotFoundTrackingEvent, Package, PostingList, ShippingLabel, TrackingCode
+from correios.models.posting import Freight, NotFoundTrackingEvent, Package, PostingList, ShippingLabel, TrackingCode
 from correios.models.user import ExtraService, PostingCard, Service
 from correios.utils import get_wsdl_path
 
@@ -352,8 +350,10 @@ def test_calculate_freight_with_error_code_10_restricted(
     assert len(freights) == 1
 
     freight = freights[0]
+
+    assert isinstance(freight, Freight)
     assert len(freights) == 1
-    assert freight.error_code == FINAL_ZIPCODE_RESTRICTED
+    assert freight.error_code == ValidRestrictResponse.FINAL_ZIPCODE_RESTRICTED.value
     assert freight.value != 0
     assert freight.delivery_time.days == 2
     assert freight.saturday
@@ -379,8 +379,9 @@ def test_calculate_freight_with_error_code_11_restricted(
     assert len(freights) == 1
 
     freight = freights[0]
+    assert isinstance(freight, Freight)
     assert len(freights) == 1
-    assert freight.error_code == INITIAL_AND_FINAL_ZIPCODE_RESTRICTED
+    assert freight.error_code == ValidRestrictResponse.INITIAL_AND_FINAL_ZIPCODE_RESTRICTED.value
     assert freight.value != 0
     assert freight.delivery_time.days == 8
     assert freight.saturday
@@ -406,8 +407,10 @@ def test_calculate_freight_with_error_code_9_restricted(
     assert len(freights) == 1
 
     freight = freights[0]
+
+    assert isinstance(freight, Freight)
     assert len(freights) == 1
-    assert freight.error_code == INITIAL_ZIPCODE_RESTRICTED
+    assert freight.error_code == ValidRestrictResponse.INITIAL_ZIPCODE_RESTRICTED.value
     assert freight.value != 0
     assert freight.delivery_time.days == 8
     assert freight.saturday


### PR DESCRIPTION
Adicionando os valores de frete no objeto `FreightError` pois quando o CEP é restrito os correios retornam com `erro=[9, 10, 11]` e nesse caso não é um erro de fato, mas o cliente tem a possibilidade de buscar o produto na agencia mais próxima.