### PR TITLE
Refactor package exceptions

### DIFF
--- a/correios/exceptions.py
+++ b/correios/exceptions.py
@@ -54,34 +54,18 @@ class InvalidShippingLabelError(ModelError):
 
 
 class InvalidPackageError(ModelError):
-    pass
+
+    def __init__(self, errors):
+        self.errors = errors
+
+    def __str__(self):
+        if len(self.errors) > 1:
+            return "Invalid Package: {} and {}".format(", ".join(self.errors[:-1]), self.errors[-1])
+        else:
+            return "Invalid Package: {}".format(self.errors[0])
 
 
-class InvalidPackageDimensionsError(InvalidPackageError):
-    pass
-
-
-class InvalidMinPackageDimensionsError(InvalidPackageDimensionsError):
-    pass
-
-
-class InvalidMaxPackageDimensionsError(InvalidPackageDimensionsError):
-    pass
-
-
-class InvalidPackageWeightError(InvalidPackageError):
-    pass
-
-
-class InvalidMinPackageWeightError(InvalidPackageWeightError):
-    pass
-
-
-class InvalidMaxPackageWeightError(InvalidPackageWeightError):
-    pass
-
-
-class InvalidPackageSequenceError(InvalidPackageError):
+class InvalidPackageSequenceError(ModelError):
     pass
 
 

--- a/correios/exceptions.py
+++ b/correios/exceptions.py
@@ -54,17 +54,21 @@ class InvalidShippingLabelError(ModelError):
 
 
 class InvalidPackageError(ModelError):
+    pass
+
+
+class InvalidPackageSequenceError(InvalidPackageError):
+    pass
+
+
+class InvalidPackageMeasuresError(InvalidPackageError):
     def __init__(self, errors: list) -> None:
         self.errors = errors
 
     def __str__(self) -> str:
         if len(self.errors) > 1:
-            return "Invalid Package: {} and {}".format(", ".join(self.errors[:-1]), self.errors[-1])
-        return "Invalid Package: {}".format(self.errors[0])
-
-
-class InvalidPackageSequenceError(ModelError):
-    pass
+            return "Invalid Package Measures: {} and {}".format(", ".join(self.errors[:-1]), self.errors[-1])
+        return "Invalid Package Measures: {}".format(self.errors[0])
 
 
 class InvalidAddressesError(ModelError):

--- a/correios/exceptions.py
+++ b/correios/exceptions.py
@@ -54,15 +54,13 @@ class InvalidShippingLabelError(ModelError):
 
 
 class InvalidPackageError(ModelError):
-
-    def __init__(self, errors):
+    def __init__(self, errors: list) -> None:
         self.errors = errors
 
-    def __str__(self):
+    def __str__(self) -> str:
         if len(self.errors) > 1:
             return "Invalid Package: {} and {}".format(", ".join(self.errors[:-1]), self.errors[-1])
-        else:
-            return "Invalid Package: {}".format(self.errors[0])
+        return "Invalid Package: {}".format(self.errors[0])
 
 
 class InvalidPackageSequenceError(ModelError):

--- a/correios/models/errors.py
+++ b/correios/models/errors.py
@@ -33,17 +33,15 @@ class PackageDimensionError(PackageError):
         return msg.format(self.name, self.min_value, self.max_value, self.value)
 
 
-class PackageWeightError(PackageError):
-    def __init__(self, service_code: str, value: int, min_value: int, max_value: int) -> None:
-        self.service_code = service_code
-        self.value = value
-        self.min_value = min_value
-        self.max_value = max_value
+class PackageWeightError(PackageDimensionError):
+    def __init__(self, service: str, value: int, min_value: int, max_value: int) -> None:
+        super().__init__("weight", value, min_value, max_value)
+        self.service = service
 
     def __str__(self) -> str:
-        if self.service_code and self.max_value:
+        if self.service and self.max_value:
             msg = 'Invalid weight for the service {} (range: {}-{}, value: {})'
-            return msg.format(self.service_code, self.min_value, self.max_value, self.value)
+            return msg.format(self.service, self.min_value, self.max_value, self.value)
 
         msg = 'Invalid weight (min: {}, value: {})'
         return msg.format(self.min_value, self.value)

--- a/correios/models/errors.py
+++ b/correios/models/errors.py
@@ -1,0 +1,52 @@
+# Copyright 2016 Osvaldo Santana Neto
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class PackageError:
+
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg
+
+
+class PackageDimensionError(PackageError):
+
+    def __init__(self, name, value, min_value, max_value):
+        self.name = name
+        self.value = value
+        self.min_value = min_value
+        self.max_value = max_value
+
+    def __str__(self):
+        msg = 'Invalid {} (range: {}-{}, value: {})'
+        return msg.format(self.name, self.min_value, self.max_value, self.value)
+
+
+class PackageWeightError(PackageError):
+
+    def __init__(self, service, value, min_value, max_value):
+        self.service = service
+        self.value = value
+        self.min_value = min_value
+        self.max_value = max_value
+
+    def __str__(self):
+        if self.service and self.max_value:
+            msg = 'Invalid weight for the service {} (range: {}-{}, value: {})'
+            return msg.format(str(self.service), self.min_value, self.max_value, self.value)
+
+        msg = 'Invalid weight (min: {}, value: {})'
+        return msg.format(self.min_value, self.value)

--- a/correios/models/errors.py
+++ b/correios/models/errors.py
@@ -14,39 +14,36 @@
 
 
 class PackageError:
+    def __init__(self, messages: str) -> None:
+        self.messages = messages
 
-    def __init__(self, msg):
-        self.msg = msg
-
-    def __str__(self):
-        return self.msg
+    def __str__(self) -> str:
+        return self.messages
 
 
 class PackageDimensionError(PackageError):
-
-    def __init__(self, name, value, min_value, max_value):
+    def __init__(self, name: str, value: int, min_value: int, max_value: int) -> None:
         self.name = name
         self.value = value
         self.min_value = min_value
         self.max_value = max_value
 
-    def __str__(self):
+    def __str__(self) -> str:
         msg = 'Invalid {} (range: {}-{}, value: {})'
         return msg.format(self.name, self.min_value, self.max_value, self.value)
 
 
 class PackageWeightError(PackageError):
-
-    def __init__(self, service, value, min_value, max_value):
-        self.service = service
+    def __init__(self, service_code: str, value: int, min_value: int, max_value: int) -> None:
+        self.service_code = service_code
         self.value = value
         self.min_value = min_value
         self.max_value = max_value
 
-    def __str__(self):
-        if self.service and self.max_value:
+    def __str__(self) -> str:
+        if self.service_code and self.max_value:
             msg = 'Invalid weight for the service {} (range: {}-{}, value: {})'
-            return msg.format(str(self.service), self.min_value, self.max_value, self.value)
+            return msg.format(self.service_code, self.min_value, self.max_value, self.value)
 
         msg = 'Invalid weight (min: {}, value: {})'
         return msg.format(self.min_value, self.value)

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -504,7 +504,7 @@ class Package:
                          weight,
                          service: Optional[Union[Service, str, int]]=None) -> Union[errors.PackageError, None]:
         if weight <= 0:
-            return errors.PackageWeightError(None, weight, 0, None)
+            return errors.PackageWeightError('', weight, 0, 0)
 
         if not service:
             return None
@@ -515,7 +515,7 @@ class Package:
             return None
 
         if weight > service.max_weight:
-            return errors.PackageWeightError(service, weight, 0, service.max_weight)
+            return errors.PackageWeightError(service.code, weight, 0, service.max_weight)
 
         return None
 

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -310,7 +310,7 @@ class Package:
     def width(self, width):
         error = Package._validate_dimension("width", width, MAX_WIDTH)
         if error:
-            raise exceptions.InvalidPackageError([error])
+            raise exceptions.InvalidPackageMeasuresError([error])
 
         self.real_width = width
 
@@ -322,7 +322,7 @@ class Package:
     def height(self, height):
         error = Package._validate_dimension("height", height, MAX_HEIGHT)
         if error:
-            raise exceptions.InvalidPackageError([error])
+            raise exceptions.InvalidPackageMeasuresError([error])
 
         self.real_height = height
 
@@ -334,7 +334,7 @@ class Package:
     def length(self, length):
         error = Package._validate_dimension("length", length, MAX_LENGTH)
         if error:
-            raise exceptions.InvalidPackageError([error])
+            raise exceptions.InvalidPackageMeasuresError([error])
 
         self.real_length = length
 
@@ -346,7 +346,7 @@ class Package:
     def diameter(self, diameter):
         error = Package._validate_dimension("diameter", diameter, MAX_DIAMETER)
         if error:
-            raise exceptions.InvalidPackageError([error])
+            raise exceptions.InvalidPackageMeasuresError([error])
 
         self.real_diameter = diameter
 
@@ -358,7 +358,7 @@ class Package:
     def weight(self, weight):
         error = Package._validate_weight(weight, self.service)
         if error:
-            raise exceptions.InvalidPackageError([error])
+            raise exceptions.InvalidPackageMeasuresError([error])
 
         self.real_weight = weight
 
@@ -440,7 +440,7 @@ class Package:
             error_list += Package._validate_cylinder(width, height, length, diameter)
 
         if error_list:
-            raise exceptions.InvalidPackageError(error_list)
+            raise exceptions.InvalidPackageMeasuresError(error_list)
 
     @classmethod
     def _validate_envelope(cls, width, height, length, diameter) -> list:

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -493,27 +493,31 @@ class Package:
         return error_list
 
     @classmethod
-    def _validate_dimension(cls, name, value, maximum) -> (errors.PackageError, None):
+    def _validate_dimension(cls, name, value, maximum) -> Union[errors.PackageError, None]:
         if value <= 0 or value > maximum:
             return errors.PackageDimensionError(name, value, 0, maximum)
 
-        return
+        return None
 
     @classmethod
-    def _validate_weight(cls, weight, service: Optional[Union[Service, str, int]]=None) -> (errors.PackageError, None):
+    def _validate_weight(cls,
+                         weight,
+                         service: Optional[Union[Service, str, int]]=None) -> Union[errors.PackageError, None]:
         if weight <= 0:
             return errors.PackageWeightError(None, weight, 0, None)
 
         if not service:
-            return
+            return None
 
         service = Service.get(service)
 
         if service.max_weight is None:
-            return
+            return None
 
         if weight > service.max_weight:
             return errors.PackageWeightError(service, weight, 0, service.max_weight)
+
+        return None
 
 
 class ShippingLabel:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-factory-boy==2.8.1
+factory-boy==2.10.0
 pytest
 pytest-cov
 pytest-factoryboy

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -298,21 +298,21 @@ def test_package_posting_weight_calculation(weight, width, height, length, posti
 
 
 @pytest.mark.parametrize("package_type,width,height,length,diameter,exc", [
-    (posting.Package.TYPE_ENVELOPE, 1, 0, 0, 0, exceptions.InvalidPackageDimensionsError),
-    (posting.Package.TYPE_ENVELOPE, 0, 1, 0, 0, exceptions.InvalidPackageDimensionsError),
-    (posting.Package.TYPE_ENVELOPE, 0, 0, 1, 0, exceptions.InvalidPackageDimensionsError),
-    (posting.Package.TYPE_ENVELOPE, 0, 0, 0, 1, exceptions.InvalidPackageDimensionsError),
-    (posting.Package.TYPE_ENVELOPE, 1, 1, 1, 1, exceptions.InvalidPackageDimensionsError),
-    (posting.Package.TYPE_BOX, 11, 2, 16, 1, exceptions.InvalidPackageDimensionsError),  # invalid diameter
-    (posting.Package.TYPE_BOX, 110, 2, 16, 0, exceptions.InvalidMaxPackageDimensionsError),  # max width=105
-    (posting.Package.TYPE_BOX, 11, 110, 16, 0, exceptions.InvalidMaxPackageDimensionsError),  # max height=110
-    (posting.Package.TYPE_BOX, 11, 2, 110, 0, exceptions.InvalidMaxPackageDimensionsError),  # max length=110
-    (posting.Package.TYPE_BOX, 105, 105, 105, 0, exceptions.InvalidMaxPackageDimensionsError),  # sum > 200
-    (posting.Package.TYPE_CYLINDER, 1, 0, 18, 16, exceptions.InvalidPackageDimensionsError),  # invalid width
-    (posting.Package.TYPE_CYLINDER, 0, 1, 18, 16, exceptions.InvalidPackageDimensionsError),  # invalid height
-    (posting.Package.TYPE_CYLINDER, 0, 0, 110, 16, exceptions.InvalidMaxPackageDimensionsError),  # max length=105
-    (posting.Package.TYPE_CYLINDER, 0, 0, 18, 110, exceptions.InvalidMaxPackageDimensionsError),  # max diameter=91
-    (posting.Package.TYPE_CYLINDER, 0, 0, 18, 16, exceptions.InvalidMaxPackageDimensionsError),  # max cylinder size=28
+    (posting.Package.TYPE_ENVELOPE, 1, 0, 0, 0, exceptions.InvalidPackageError),
+    (posting.Package.TYPE_ENVELOPE, 0, 1, 0, 0, exceptions.InvalidPackageError),
+    (posting.Package.TYPE_ENVELOPE, 0, 0, 1, 0, exceptions.InvalidPackageError),
+    (posting.Package.TYPE_ENVELOPE, 0, 0, 0, 1, exceptions.InvalidPackageError),
+    (posting.Package.TYPE_ENVELOPE, 1, 1, 1, 1, exceptions.InvalidPackageError),
+    (posting.Package.TYPE_BOX, 11, 2, 16, 1, exceptions.InvalidPackageError),  # invalid diameter
+    (posting.Package.TYPE_BOX, 110, 2, 16, 0, exceptions.InvalidPackageError),  # max width=105
+    (posting.Package.TYPE_BOX, 11, 110, 16, 0, exceptions.InvalidPackageError),  # max height=110
+    (posting.Package.TYPE_BOX, 11, 2, 110, 0, exceptions.InvalidPackageError),  # max length=110
+    (posting.Package.TYPE_BOX, 105, 105, 105, 0, exceptions.InvalidPackageError),  # sum > 200
+    (posting.Package.TYPE_CYLINDER, 1, 0, 18, 16, exceptions.InvalidPackageError),  # invalid width
+    (posting.Package.TYPE_CYLINDER, 0, 1, 18, 16, exceptions.InvalidPackageError),  # invalid height
+    (posting.Package.TYPE_CYLINDER, 0, 0, 110, 16, exceptions.InvalidPackageError),  # max length=105
+    (posting.Package.TYPE_CYLINDER, 0, 0, 18, 110, exceptions.InvalidPackageError),  # max diameter=91
+    (posting.Package.TYPE_CYLINDER, 0, 0, 18, 16, exceptions.InvalidPackageError),  # max cylinder size=28
 ])
 def test_fail_package_dimensions_validation(package_type, width, height, length, diameter, exc):
     with pytest.raises(exc):
@@ -336,7 +336,7 @@ def test_package_weight_validation():
 
 
 def test_fail_package_weight_validation():
-    with pytest.raises(exceptions.InvalidMaxPackageWeightError):
+    with pytest.raises(exceptions.InvalidPackageError):
         posting.Package.validate(
             posting.Package.TYPE_BOX,
             12, 10, 20,
@@ -396,14 +396,14 @@ def test_cylinder_package_change_dimensions_below_minimum(package, dimension, va
 
 
 @pytest.mark.parametrize("dimension,value,exc", [
-    ("width", 0, exceptions.InvalidMinPackageDimensionsError),
-    ("width", posting.MAX_WIDTH + 1, exceptions.InvalidMaxPackageDimensionsError),
-    ("height", 0, exceptions.InvalidMinPackageDimensionsError),
-    ("height", posting.MAX_HEIGHT + 1, exceptions.InvalidMaxPackageDimensionsError),
-    ("length", 0, exceptions.InvalidMinPackageDimensionsError),
-    ("length", posting.MAX_LENGTH + 1, exceptions.InvalidMaxPackageDimensionsError),
-    ("weight", 0, exceptions.InvalidMinPackageWeightError),
-    ("weight", 100000, exceptions.InvalidMaxPackageWeightError),
+    ("width", 0, exceptions.InvalidPackageError),
+    ("width", posting.MAX_WIDTH + 1, exceptions.InvalidPackageError),
+    ("height", 0, exceptions.InvalidPackageError),
+    ("height", posting.MAX_HEIGHT + 1, exceptions.InvalidPackageError),
+    ("length", 0, exceptions.InvalidPackageError),
+    ("length", posting.MAX_LENGTH + 1, exceptions.InvalidPackageError),
+    ("weight", 0, exceptions.InvalidPackageError),
+    ("weight", 100000, exceptions.InvalidPackageError),
 ])
 def test_fail_box_package_change_invalid_dimensions(package, dimension, value, exc):
     with pytest.raises(exc):
@@ -411,10 +411,10 @@ def test_fail_box_package_change_invalid_dimensions(package, dimension, value, e
 
 
 @pytest.mark.parametrize("dimension,value,exc", [
-    ("diameter", 0, exceptions.InvalidMinPackageDimensionsError),
-    ("diameter", posting.MAX_DIAMETER + 1, exceptions.InvalidMaxPackageDimensionsError),
-    ("length", 0, exceptions.InvalidMinPackageDimensionsError),
-    ("length", posting.MAX_LENGTH + 1, exceptions.InvalidMaxPackageDimensionsError),
+    ("diameter", 0, exceptions.InvalidPackageError),
+    ("diameter", posting.MAX_DIAMETER + 1, exceptions.InvalidPackageError),
+    ("length", 0, exceptions.InvalidPackageError),
+    ("length", posting.MAX_LENGTH + 1, exceptions.InvalidPackageError),
 ])
 def test_fail_cylinder_package_change_invalid_dimensions(package, dimension, value, exc):
     package.package_type = package.TYPE_CYLINDER

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -298,21 +298,21 @@ def test_package_posting_weight_calculation(weight, width, height, length, posti
 
 
 @pytest.mark.parametrize("package_type,width,height,length,diameter,exc", [
-    (posting.Package.TYPE_ENVELOPE, 1, 0, 0, 0, exceptions.InvalidPackageError),
-    (posting.Package.TYPE_ENVELOPE, 0, 1, 0, 0, exceptions.InvalidPackageError),
-    (posting.Package.TYPE_ENVELOPE, 0, 0, 1, 0, exceptions.InvalidPackageError),
-    (posting.Package.TYPE_ENVELOPE, 0, 0, 0, 1, exceptions.InvalidPackageError),
-    (posting.Package.TYPE_ENVELOPE, 1, 1, 1, 1, exceptions.InvalidPackageError),
-    (posting.Package.TYPE_BOX, 11, 2, 16, 1, exceptions.InvalidPackageError),  # invalid diameter
-    (posting.Package.TYPE_BOX, 110, 2, 16, 0, exceptions.InvalidPackageError),  # max width=105
-    (posting.Package.TYPE_BOX, 11, 110, 16, 0, exceptions.InvalidPackageError),  # max height=110
-    (posting.Package.TYPE_BOX, 11, 2, 110, 0, exceptions.InvalidPackageError),  # max length=110
-    (posting.Package.TYPE_BOX, 105, 105, 105, 0, exceptions.InvalidPackageError),  # sum > 200
-    (posting.Package.TYPE_CYLINDER, 1, 0, 18, 16, exceptions.InvalidPackageError),  # invalid width
-    (posting.Package.TYPE_CYLINDER, 0, 1, 18, 16, exceptions.InvalidPackageError),  # invalid height
-    (posting.Package.TYPE_CYLINDER, 0, 0, 110, 16, exceptions.InvalidPackageError),  # max length=105
-    (posting.Package.TYPE_CYLINDER, 0, 0, 18, 110, exceptions.InvalidPackageError),  # max diameter=91
-    (posting.Package.TYPE_CYLINDER, 0, 0, 18, 16, exceptions.InvalidPackageError),  # max cylinder size=28
+    (posting.Package.TYPE_ENVELOPE, 1, 0, 0, 0, exceptions.InvalidPackageMeasuresError),
+    (posting.Package.TYPE_ENVELOPE, 0, 1, 0, 0, exceptions.InvalidPackageMeasuresError),
+    (posting.Package.TYPE_ENVELOPE, 0, 0, 1, 0, exceptions.InvalidPackageMeasuresError),
+    (posting.Package.TYPE_ENVELOPE, 0, 0, 0, 1, exceptions.InvalidPackageMeasuresError),
+    (posting.Package.TYPE_ENVELOPE, 1, 1, 1, 1, exceptions.InvalidPackageMeasuresError),
+    (posting.Package.TYPE_BOX, 11, 2, 16, 1, exceptions.InvalidPackageMeasuresError),  # invalid diameter
+    (posting.Package.TYPE_BOX, 110, 2, 16, 0, exceptions.InvalidPackageMeasuresError),  # max width=105
+    (posting.Package.TYPE_BOX, 11, 110, 16, 0, exceptions.InvalidPackageMeasuresError),  # max height=110
+    (posting.Package.TYPE_BOX, 11, 2, 110, 0, exceptions.InvalidPackageMeasuresError),  # max length=110
+    (posting.Package.TYPE_BOX, 105, 105, 105, 0, exceptions.InvalidPackageMeasuresError),  # sum > 200
+    (posting.Package.TYPE_CYLINDER, 1, 0, 18, 16, exceptions.InvalidPackageMeasuresError),  # invalid width
+    (posting.Package.TYPE_CYLINDER, 0, 1, 18, 16, exceptions.InvalidPackageMeasuresError),  # invalid height
+    (posting.Package.TYPE_CYLINDER, 0, 0, 110, 16, exceptions.InvalidPackageMeasuresError),  # max length=105
+    (posting.Package.TYPE_CYLINDER, 0, 0, 18, 110, exceptions.InvalidPackageMeasuresError),  # max diameter=91
+    (posting.Package.TYPE_CYLINDER, 0, 0, 18, 16, exceptions.InvalidPackageMeasuresError),  # max cylinder size=28
 ])
 def test_fail_package_dimensions_validation(package_type, width, height, length, diameter, exc):
     with pytest.raises(exc):
@@ -336,7 +336,7 @@ def test_package_weight_validation():
 
 
 def test_fail_package_weight_validation():
-    with pytest.raises(exceptions.InvalidPackageError):
+    with pytest.raises(exceptions.InvalidPackageMeasuresError):
         posting.Package.validate(
             posting.Package.TYPE_BOX,
             12, 10, 20,
@@ -396,14 +396,14 @@ def test_cylinder_package_change_dimensions_below_minimum(package, dimension, va
 
 
 @pytest.mark.parametrize("dimension,value,exc", [
-    ("width", 0, exceptions.InvalidPackageError),
-    ("width", posting.MAX_WIDTH + 1, exceptions.InvalidPackageError),
-    ("height", 0, exceptions.InvalidPackageError),
-    ("height", posting.MAX_HEIGHT + 1, exceptions.InvalidPackageError),
-    ("length", 0, exceptions.InvalidPackageError),
-    ("length", posting.MAX_LENGTH + 1, exceptions.InvalidPackageError),
-    ("weight", 0, exceptions.InvalidPackageError),
-    ("weight", 100000, exceptions.InvalidPackageError),
+    ("width", 0, exceptions.InvalidPackageMeasuresError),
+    ("width", posting.MAX_WIDTH + 1, exceptions.InvalidPackageMeasuresError),
+    ("height", 0, exceptions.InvalidPackageMeasuresError),
+    ("height", posting.MAX_HEIGHT + 1, exceptions.InvalidPackageMeasuresError),
+    ("length", 0, exceptions.InvalidPackageMeasuresError),
+    ("length", posting.MAX_LENGTH + 1, exceptions.InvalidPackageMeasuresError),
+    ("weight", 0, exceptions.InvalidPackageMeasuresError),
+    ("weight", 100000, exceptions.InvalidPackageMeasuresError),
 ])
 def test_fail_box_package_change_invalid_dimensions(package, dimension, value, exc):
     with pytest.raises(exc):
@@ -411,10 +411,10 @@ def test_fail_box_package_change_invalid_dimensions(package, dimension, value, e
 
 
 @pytest.mark.parametrize("dimension,value,exc", [
-    ("diameter", 0, exceptions.InvalidPackageError),
-    ("diameter", posting.MAX_DIAMETER + 1, exceptions.InvalidPackageError),
-    ("length", 0, exceptions.InvalidPackageError),
-    ("length", posting.MAX_LENGTH + 1, exceptions.InvalidPackageError),
+    ("diameter", 0, exceptions.InvalidPackageMeasuresError),
+    ("diameter", posting.MAX_DIAMETER + 1, exceptions.InvalidPackageMeasuresError),
+    ("length", 0, exceptions.InvalidPackageMeasuresError),
+    ("length", posting.MAX_LENGTH + 1, exceptions.InvalidPackageMeasuresError),
 ])
 def test_fail_cylinder_package_change_invalid_dimensions(package, dimension, value, exc):
     package.package_type = package.TYPE_CYLINDER


### PR DESCRIPTION
**Warning:** This PR makes incompatible API changes. We need to change the major version after merging it.

These changes modify how the `Package` model `validate` method raises exceptions. Now all validation are made without stopping on the first error, and its errors are grouped inside one Exception.

Also, I've fixed a _catch'em all_ except.