### PR TITLE
Update services min declared value

### DIFF
--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -275,7 +275,7 @@ SERVICES = {
         'display_name': 'SEDEX 10',
         'symbol': "premium",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '81019': {
@@ -286,7 +286,7 @@ SERVICES = {
         'display_name': 'E-SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '41068': {
@@ -297,7 +297,7 @@ SERVICES = {
         'max_weight': 30000,
         'symbol': "standard",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("3000.00"),
     },
     '04669': {
@@ -308,7 +308,7 @@ SERVICES = {
         'max_weight': 30000,
         'symbol': "standard",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("3000.00"),
     },
     '40444': {
@@ -319,7 +319,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '40436': {
@@ -330,7 +330,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '40096': {
@@ -341,7 +341,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '04162': {
@@ -352,7 +352,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '40380': {
@@ -363,7 +363,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '40010': {
@@ -374,7 +374,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '41211': {
@@ -385,7 +385,7 @@ SERVICES = {
         'max_weight': 30000,
         'symbol': "standard",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("3000.00"),
     },
     '40630': {
@@ -396,7 +396,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '40916': {
@@ -407,7 +407,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '40908': {
@@ -418,7 +418,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '41300': {
@@ -429,7 +429,7 @@ SERVICES = {
         'display_name': 'PAC',
         'symbol': "standard",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("3000.00"),
     },
     '40169': {
@@ -440,7 +440,7 @@ SERVICES = {
         'display_name': 'SEDEX 12',
         'symbol': "premium",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '40290': {
@@ -451,7 +451,7 @@ SERVICES = {
         'display_name': 'SEDEX Hoje',
         'symbol': "premium",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("17.00"),
+        'min_declared_value': Decimal("18.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '10154': {

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-factory-boy==2.8.1
+factory-boy
 pytest
 pytest-cov
 pytest-factoryboy

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -233,7 +233,7 @@ def test_declared_value(posting_list, shipping_label):
     xml = serializer.get_xml(document)
     assert shipping_label.service == Service.get(SERVICE_PAC)
     assert b"<codigo_servico_adicional>019</codigo_servico_adicional>" in xml
-    assert b"<valor_declarado>18,00</valor_declarado>" in xml
+    assert b"<valor_declarado>18,50</valor_declarado>" in xml
 
 
 @pytest.mark.skipif(not correios, reason="API Client support disabled")

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -210,7 +210,7 @@ def test_shipping_label_with_min_declared_value_pac(posting_card, sender_address
         value=Decimal("0"),
         extra_services=[EXTRA_SERVICE_VD],
     )
-    assert shipping_label.value == Decimal("18.00")
+    assert shipping_label.value == Decimal("18.50")
 
 
 def test_shipping_label_with_min_declared_value_sedex(posting_card, sender_address, receiver_address, package):
@@ -225,7 +225,7 @@ def test_shipping_label_with_min_declared_value_sedex(posting_card, sender_addre
         value=Decimal("0"),
         extra_services=[EXTRA_SERVICE_VD],
     )
-    assert shipping_label.value == Decimal("18.00")
+    assert shipping_label.value == Decimal("18.50")
 
 
 def test_fail_shipping_label_with_invalid_declared_value(posting_card, sender_address, receiver_address, package):


### PR DESCRIPTION
The minimum declared value for all services has been updated by Correios. This PR update these values.

The minimum declared value per service is ten times the minimum basic value (currently 1.85[1]).

[1] - https://www.correios.com.br/para-voce/consultas-e-solicitacoes/precos-e-prazos/servicos-nacionais_pasta/carta