### PR TITLE
Handle posting list and posting card errors

### DIFF
--- a/correios/client.py
+++ b/correios/client.py
@@ -107,23 +107,19 @@ class Correios:
 
         self.model_builder = ModelBuilder()
 
-    def _exception_call(self, exception):
+    def _parse_exception(self, exception):
         message = str(exception)
-        exception = ClientError(message)
 
         if "autenticacao" in message:
-            message = "Authentication error for user {}".format(self.username)
-            exception = AuthenticationError(message)
+            return AuthenticationError("Authentication error for user {}".format(self.username))
 
         if message.startswith("O Cartão de Postagem") and message.endswith("Cancelado."):
-            message = "The posting card is canceled"
-            exception = CanceledPostingCardError(message)
+            return CanceledPostingCardError("The posting card is canceled")
 
         if message.startswith('Cartao de Postagem inexistente'):
-            message = "Nonexistent posting card"
-            exception = NonexistentPostingCardError(message)
+            return NonexistentPostingCardError("Nonexistent posting card")
 
-        return exception
+        return ClientError(message)
 
     def _auth_call(self, method_name, *args, **kwargs):
         kwargs.update({
@@ -141,7 +137,7 @@ class Correios:
             raise ConnectTimeoutError("Timeout connection error ({} seconds)".format(self.timeout))
 
         except Fault as exc:
-            raise self._exception_call(exc)
+            raise self._parse_exception(exc)
 
     def get_user(self, contract_number: Union[int, str], posting_card_number: Union[int, str]) -> User:
         contract_number = str(contract_number)

--- a/correios/client.py
+++ b/correios/client.py
@@ -14,7 +14,6 @@
 
 
 import re
-from collections import namedtuple
 from decimal import Decimal
 from pathlib import Path
 from typing import List, Optional, Sequence, Union
@@ -61,22 +60,11 @@ CORREIOS_WEBSERVICES = {
     ),
 }
 
-CorreiosAPIError = namedtuple('CorreiosAPIError', ['regex', 'exception'])
-
-ERRORS = (
-    CorreiosAPIError(
-        regex=re.compile(r"autenticacao"),
-        exception=AuthenticationError,
-    ),
-    CorreiosAPIError(
-        regex=re.compile(r"^O Cartão de Postagem.*Cancelado.$"),
-        exception=CanceledPostingCardError,
-    ),
-    CorreiosAPIError(
-        regex=re.compile(r"^Cartao de Postagem inexistente"),
-        exception=NonexistentPostingCardError,
-    ),
-)
+ERRORS = {
+    re.compile(r"autenticacao"): AuthenticationError,
+    re.compile(r"^O Cartão de Postagem.*Cancelado.$"): CanceledPostingCardError,
+    re.compile(r"^Cartao de Postagem inexistente"): NonexistentPostingCardError,
+}
 
 
 class Correios:
@@ -129,7 +117,7 @@ class Correios:
     def _handle_exception(self, exception):
         message = str(exception)
 
-        for regex, exception in ERRORS:
+        for regex, exception in ERRORS.items():
             if regex.search(message):
                 raise exception(message)
 

--- a/correios/client.py
+++ b/correios/client.py
@@ -198,6 +198,7 @@ class Correios:
                 message = "Unable to close PLP. Tracking codes {} are already assigned to another PLP"
                 message = message.format(tracking_codes)
                 raise ClosePostingListError(message)
+            raise
 
         posting_list.close_with_id(id_)
         return posting_list

--- a/correios/client.py
+++ b/correios/client.py
@@ -111,21 +111,27 @@ class Correios:
     def _parse_exception(self, exception):
         message = str(exception)
 
-        ERRORS = (
-            (AuthenticationError, "Authentication error for user {}".format(self.username)),
-            (CanceledPostingCardError, "The posting card is canceled"),
-            (NonexistentPostingCardError, "Nonexistent posting card"),
+        ERROR_EXCEPTIONS = (
+            AuthenticationError,
+            CanceledPostingCardError,
+            NonexistentPostingCardError,
         )
 
-        ERROR_MESSAGES = {
-            re.compile(r"autenticacao"): ERRORS[0],
-            re.compile(r"^O Cartão de Postagem.*Cancelado.$"): ERRORS[1],
-            re.compile(r"^Cartao de Postagem inexistente"): ERRORS[2],
-        }
+        ERROR_MESSAGES = (
+            "Authentication error for user {}".format(self.username),
+            "The posting card is canceled",
+            "Nonexistent posting card",
+        )
 
-        for regex, (exc, error_message) in ERROR_MESSAGES.items():
+        ERROR_REGEXES = (
+            re.compile(r"autenticacao"),
+            re.compile(r"^O Cartão de Postagem.*Cancelado.$"),
+            re.compile(r"^Cartao de Postagem inexistente"),
+        )
+
+        for regex, exception, error_message in zip(ERROR_REGEXES, ERROR_EXCEPTIONS, ERROR_MESSAGES):
             if regex.search(message):
-                return exc(error_message)
+                return exception(error_message)
 
         return ClientError(message)
 

--- a/correios/client.py
+++ b/correios/client.py
@@ -126,7 +126,7 @@ class Correios:
 
         self.model_builder = ModelBuilder()
 
-    def _parse_exception(self, exception):
+    def _handle_exception(self, exception):
         message = str(exception)
 
         for regex, exception in ERRORS:
@@ -151,7 +151,7 @@ class Correios:
             raise ConnectTimeoutError("Timeout connection error ({} seconds)".format(self.timeout))
 
         except Fault as exc:
-            self._parse_exception(exc)
+            self._handle_exception(exc)
 
     def get_user(self, contract_number: Union[int, str], posting_card_number: Union[int, str]) -> User:
         contract_number = str(contract_number)

--- a/correios/exceptions.py
+++ b/correios/exceptions.py
@@ -117,6 +117,18 @@ class ConnectTimeoutError(ClientError):
     pass
 
 
+class ClosePostingListError(ClientError):
+    pass
+
+
+class CanceledPostingCardError(ClientError):
+    pass
+
+
+class NonexistentPostingCardError(ClientError):
+    pass
+
+
 class RendererError(BaseCorreiosError):
     pass
 

--- a/tests/fixtures/cassettes/test_client_canceled_posting_card_error.yaml
+++ b/tests/fixtures/cassettes/test_client_canceled_posting_card_error.yaml
@@ -1,0 +1,35 @@
+interactions:
+- request:
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:buscaCliente
+      xmlns:ns0="http://cliente.bean.master.sigep.bsb.correios.com.br/"><idContrato>9911222777</idContrato><idCartaoPostagem>0057018901</idCartaoPostagem><usuario>sigep</usuario><senha>n5f9t8</senha></ns0:buscaCliente></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['398']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['""']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: POST
+    uri: https://apphom.correios.com.br/SigepMasterJPA/AtendeClienteService/AtendeCliente
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA51RQU4DMQz8StQHJFskBKxCDlTlWqS+IJs120jZOIrdqjwH8ZR+jKQNUA5cOGU0
+        nrFmHE1oU7+OBwiYQBznEKmv3ONix5x6pcjtYLYky6jyEvOkKlDQTGph9HnLE45vDT7bfWCjX+vj
+        cARzZreQD5C1+qEvCuLs42Q2YmUznz5QjCBekNhOMIuuu73rlvcP3VIA8em9iKKDYEeUbVOz6xHY
+        +mB0pJt+6ydIq+AhMqyPDhJ7jK1emX+3cxeJHMBGWWoyZEnVKwcapMOcwSMVMMshl6b/yPhnHKPV
+        V2R1fTV1dU3163/MJ2TF2QOvAQAA
+    headers:
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['249']
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Wed, 28 Feb 2018 13:42:30 GMT']
+      Set-Cookie: [JSESSIONID=F-ktJpTpPsFguTq49Y-+WPZu.87ce37da-a934-3ec7-b3ca-869e2306cbff;
+          Path=/SigepMasterJPA; Secure]
+      Vary: ['Accept-Encoding,User-Agent']
+    status: {code: 500, message: Internal Server Error}
+version: 1

--- a/tests/fixtures/cassettes/test_client_nonexistent_posting_card_error.yaml
+++ b/tests/fixtures/cassettes/test_client_nonexistent_posting_card_error.yaml
@@ -1,0 +1,35 @@
+interactions:
+- request:
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
+
+      <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"><soap-env:Body><ns0:buscaCliente
+      xmlns:ns0="http://cliente.bean.master.sigep.bsb.correios.com.br/"><idContrato>9911222777</idContrato><idCartaoPostagem>4444444444</idCartaoPostagem><usuario>sigep</usuario><senha>n5f9t8</senha></ns0:buscaCliente></soap-env:Body></soap-env:Envelope>'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['398']
+      Content-Type: [text/xml; charset=utf-8]
+      SOAPAction: ['""']
+      User-Agent: [Zeep/2.5.0 (www.python-zeep.org)]
+    method: POST
+    uri: https://apphom.correios.com.br/SigepMasterJPA/AtendeClienteService/AtendeCliente
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA41RQW4DIQz8CsoDsJTjinJotD1HzQtY1t0gsRhhJ9r+vpDQNjlU6onReAbN2IbJ
+        5WFMV4yUUW1rTDw07mV3FskDAPszro51HTVeU1mgAcBugp01t19eaf7s8M1doljz0R5PM9obe8Jy
+        xWLgl74rWEpIiz24Io7UjOpILG7BVYWEW2DBJKgSqfH9qLu9e8yM4kK0JvF+OIUF8yGGJh83j1kC
+        pd6pzn8q+btET+iSrt0Ei+bm1RNP2lMpGIgrWPVUar3/BvszgzXwnRMe9wMPe4OnS9gvht0ZBZkB
+        AAA=
+    headers:
+      Connection: [close]
+      Content-Encoding: [gzip]
+      Content-Length: ['230']
+      Content-Type: [text/xml;charset=UTF-8]
+      Date: ['Wed, 28 Feb 2018 13:32:12 GMT']
+      Set-Cookie: [JSESSIONID=-PguPJ2EuGyA4fnoyd3iiDO0.39987725-7faa-3e86-8a45-e6c0e8576534;
+          Path=/SigepMasterJPA; Secure]
+      Vary: ['Accept-Encoding,User-Agent']
+    status: {code: 500, message: Internal Server Error}
+version: 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -42,14 +42,7 @@ from correios.models.data import (
     SERVICE_SEDEX,
     SERVICE_SEDEX10,
 )
-from correios.models.posting import (
-    FreightResponse,
-    NotFoundTrackingEvent,
-    Package,
-    PostingList,
-    ShippingLabel,
-    TrackingCode,
-)
+from correios.models.posting import FreightResponse, NotFoundTrackingEvent, TrackingCode
 from correios.models.user import ExtraService, PostingCard, Service
 from correios.serializers import PostingListSerializer
 from correios.utils import get_resource_path
@@ -161,7 +154,7 @@ def test_generate_verification_digit(client):
 
 @pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
-def test_close_posting_list(client, posting_card, posting_list: PostingList, shipping_label: ShippingLabel):
+def test_close_posting_list(client, posting_card, posting_list, shipping_label):
     shipping_label.posting_card = posting_card
     posting_list.add_shipping_label(shipping_label)
     posting_list = client.close_posting_list(posting_list, posting_card)
@@ -175,8 +168,8 @@ def test_client_close_posting_list_error(
     mock_soap_client,
     client,
     posting_card,
-    posting_list: PostingList,
-    shipping_label: ShippingLabel
+    posting_list,
+    shipping_label,
 ):
     mock_soap_client.side_effect = Fault(
         'A PLP não será fechada , o(s) objeto(s) [PP40233163BR] já estão '
@@ -303,7 +296,7 @@ def test_fail_empty_posting_list_serialization(posting_list):
 
 
 @pytest.mark.skipif(not correios, reason="API Client support disabled")
-def test_fail_closed_posting_list_serialization(posting_list: PostingList, shipping_label):
+def test_fail_closed_posting_list_serialization(posting_list, shipping_label):
     posting_list.add_shipping_label(shipping_label)
     posting_list.close_with_id(number=12345)
 
@@ -376,7 +369,7 @@ def test_calculate_freights_with_extra_services(client, posting_card, package):
 
 @pytest.mark.skipif(not correios, reason="API Client support disabled")
 @vcr.use_cassette
-def test_calculate_freight_with_error(client, posting_card, package: Package):
+def test_calculate_freight_with_error(client, posting_card, package):
     package.real_weight = 80000  # invalid weight (80kg)
     freights = client.calculate_freights(posting_card, [SERVICE_SEDEX], "99999000", "99999999", package)
     assert len(freights) == 1


### PR DESCRIPTION
This PR aims to handle more specific errors, like posting list and posting card errors, to allow users to treat errors in a granular way. In addition don't need to import exceptions from another dependencies like `requests.exceptions.Timeout` or `zeep.exceptions.Fault`.

Unfortunately, errors are treated by checking error messages returned from `zeep.exceptions.Fault` because `code` attribute do not return any relevant information.
```python
(Pdb) exc.code
'soap:Server'
```


