### PR TITLE
Fix Package diameter property

### DIFF
--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -331,9 +331,9 @@ class Package:
 
     @property
     def diameter(self) -> int:
-        if self.package_type == Package.TYPE_CYLINDER:
-            return max(MIN_DIAMETER, int(math.ceil(self.real_diameter)))
-        return 0
+        if self.package_type != Package.TYPE_CYLINDER:
+            return 0
+        return max(MIN_DIAMETER, int(math.ceil(self.real_diameter)))
 
     @diameter.setter
     def diameter(self, diameter):

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -331,7 +331,9 @@ class Package:
 
     @property
     def diameter(self) -> int:
-        return max(MIN_DIAMETER, int(math.ceil(self.real_diameter)))
+        if self.package_type == Package.TYPE_CYLINDER:
+            return max(MIN_DIAMETER, int(math.ceil(self.real_diameter)))
+        return 0
 
     @diameter.setter
     def diameter(self, diameter):

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -358,6 +358,16 @@ def test_fix_bug_of_weight_using_diameter_information():
     assert package.real_diameter == 2
 
 
+@pytest.mark.parametrize('package_type,diameter', [
+    ('TYPE_ENVELOPE', 0),
+    ('TYPE_BOX', 0),
+    ('TYPE_CYLINDER', 16),
+])
+def test_package_diameter(package, package_type, diameter):
+    package.package_type = getattr(package, package_type)
+    assert package.diameter == diameter
+
+
 @pytest.mark.parametrize("sequence", [
     (1,),
     (3, 2),

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -358,14 +358,16 @@ def test_fix_bug_of_weight_using_diameter_information():
     assert package.real_diameter == 2
 
 
-@pytest.mark.parametrize('package_type,diameter', [
-    ('TYPE_ENVELOPE', 0),
-    ('TYPE_BOX', 0),
-    ('TYPE_CYLINDER', 16),
+@pytest.mark.parametrize('package_type,diameter,result', [
+    ('TYPE_ENVELOPE', 16, 0),
+    ('TYPE_BOX', 18, 0),
+    ('TYPE_CYLINDER', 3, 16),
+    ('TYPE_CYLINDER', 18, 18),
 ])
-def test_package_diameter(package, package_type, diameter):
+def test_package_diameter(package, package_type, diameter, result):
     package.package_type = getattr(package, package_type)
-    assert package.diameter == diameter
+    package.real_diameter = diameter
+    assert package.diameter == result
 
 
 @pytest.mark.parametrize("sequence", [

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -359,13 +359,13 @@ def test_fix_bug_of_weight_using_diameter_information():
 
 
 @pytest.mark.parametrize('package_type,diameter,result', [
-    ('TYPE_ENVELOPE', 16, 0),
-    ('TYPE_BOX', 18, 0),
-    ('TYPE_CYLINDER', 3, 16),
-    ('TYPE_CYLINDER', 18, 18),
+    (posting.Package.TYPE_ENVELOPE, 16, 0),
+    (posting.Package.TYPE_BOX, 18, 0),
+    (posting.Package.TYPE_CYLINDER, 3, 16),
+    (posting.Package.TYPE_CYLINDER, 18, 18),
 ])
 def test_package_diameter(package, package_type, diameter, result):
-    package.package_type = getattr(package, package_type)
+    package.package_type = package_type
     package.real_diameter = diameter
     assert package.diameter == result
 


### PR DESCRIPTION
According to [new version of Correios' documentation](https://github.com/olist/correios/blob/master/documentation/v4-Manual_de_Implementacao_do_Web_Service_SIGEP_WEB.pdf), the package diameter only needs to be calculate if the object type is equal 003, cylinder, otherwise must return 0, as we can see in the image below.

![screenshot from 2018-03-09 09-36-05](https://user-images.githubusercontent.com/8885756/37207969-3eb40f7c-237e-11e8-8c25-2d71206b0a24.png)



