### PR TITLE
Add package is mechanizable validation

### DIFF
--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -380,7 +380,7 @@ class Package:
     def is_mechanizable(self) -> bool:
         if self.package_type == Package.TYPE_CYLINDER:
             return False
-        return MAX_MECHANIZABLE_PACKAGE_SIZE >= max(self.width, self.height, self.length)
+        return max(self.width, self.height, self.length) <= MAX_MECHANIZABLE_PACKAGE_SIZE
 
     @classmethod
     def calculate_volumetric_weight(cls, width, height, length) -> int:

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -51,8 +51,7 @@ MIN_DIAMETER, MAX_DIAMETER = 5, 91  # cm
 MIN_CYLINDER_LENGTH, MAX_CYLINDER_LENGTH = 18, 105  # cm
 MIN_SIZE, MAX_SIZE = 29, 200  # cm
 MIN_CYLINDER_SIZE, MAX_CYLINDER_SIZE = 28, 200  # cm
-MAX_MECHANIZABLE_SIZE = 70  # cm
-NON_MECHANIZABLE_COST = Decimal('20.00')
+MAX_MECHANIZABLE_PACKAGE_SIZE = 70  # cm
 
 
 INSURANCE_VALUE_THRESHOLDS = {
@@ -378,18 +377,10 @@ class Package:
         return self.freight_package_types[self.package_type]
 
     @property
-    def non_mechanizable_cost(self) -> Decimal:
+    def is_mechanizable(self) -> bool:
         if self.package_type == Package.TYPE_CYLINDER:
-            return NON_MECHANIZABLE_COST
-        return Package.non_mechanizable_additional_cost(self.width, self.height, self.length)
-
-    @classmethod
-    def non_mechanizable_additional_cost(cls, width, height, length) -> Decimal:
-        for value in [width, height, length]:
-            if value > MAX_MECHANIZABLE_SIZE:
-                return NON_MECHANIZABLE_COST
-
-        return Decimal('0.00')
+            return False
+        return MAX_MECHANIZABLE_PACKAGE_SIZE >= max(self.width, self.height, self.length)
 
     @classmethod
     def calculate_volumetric_weight(cls, width, height, length) -> int:

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -51,6 +51,9 @@ MIN_DIAMETER, MAX_DIAMETER = 5, 91  # cm
 MIN_CYLINDER_LENGTH, MAX_CYLINDER_LENGTH = 18, 105  # cm
 MIN_SIZE, MAX_SIZE = 29, 200  # cm
 MIN_CYLINDER_SIZE, MAX_CYLINDER_SIZE = 28, 200  # cm
+MAX_MECHANIZABLE_SIZE = 70  # cm
+NON_MECHANIZABLE_COST = Decimal('20.00')
+
 
 INSURANCE_VALUE_THRESHOLDS = {
     Service.get(SERVICE_PAC).code: INSURANCE_VALUE_THRESHOLD_PAC,
@@ -373,6 +376,20 @@ class Package:
           3   |    2    | Cylinder
         """
         return self.freight_package_types[self.package_type]
+
+    @property
+    def non_mechanizable_cost(self) -> Decimal:
+        if self.package_type == Package.TYPE_CYLINDER:
+            return NON_MECHANIZABLE_COST
+        return Package.non_mechanizable_additional_cost(self.width, self.height, self.length)
+
+    @classmethod
+    def non_mechanizable_additional_cost(cls, width, height, length) -> Decimal:
+        for value in [width, height, length]:
+            if value > MAX_MECHANIZABLE_SIZE:
+                return NON_MECHANIZABLE_COST
+
+        return Decimal('0.00')
 
     @classmethod
     def calculate_volumetric_weight(cls, width, height, length) -> int:

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -599,28 +599,15 @@ def test_basic_freight_conversion():
 
 
 @pytest.mark.parametrize('package_type,width,height,length,diameter,result', [
-    (posting.Package.TYPE_BOX, 11, 10, 16, 0, Decimal('0.00')),
-    (posting.Package.TYPE_BOX, 70, 10, 10, 0, Decimal('0.00')),
-    (posting.Package.TYPE_BOX, 10, 70, 10, 0, Decimal('0.00')),
-    (posting.Package.TYPE_BOX, 10, 10, 70, 0, Decimal('0.00')),
-    (posting.Package.TYPE_BOX, 71, 10, 10, 0, posting.NON_MECHANIZABLE_COST),
-    (posting.Package.TYPE_BOX, 10, 71, 10, 0, posting.NON_MECHANIZABLE_COST),
-    (posting.Package.TYPE_BOX, 10, 10, 71, 0, posting.NON_MECHANIZABLE_COST),
-    (posting.Package.TYPE_CYLINDER, 0, 0, 14, 2, posting.NON_MECHANIZABLE_COST),
+    (posting.Package.TYPE_BOX, 11, 10, 16, 0, True),
+    (posting.Package.TYPE_BOX, 70, 10, 10, 0, True),
+    (posting.Package.TYPE_BOX, 10, 70, 10, 0, True),
+    (posting.Package.TYPE_BOX, 10, 10, 70, 0, True),
+    (posting.Package.TYPE_BOX, 71, 10, 10, 0, False),
+    (posting.Package.TYPE_BOX, 10, 71, 10, 0, False),
+    (posting.Package.TYPE_BOX, 10, 10, 71, 0, False),
+    (posting.Package.TYPE_CYLINDER, 0, 0, 14, 2, False),
 ])
-def test_non_mechanizable_cost(package_type, width, height, length, diameter, result):
+def test_package_is_mechanizable(package_type, width, height, length, diameter, result):
     package = posting.Package(package_type, width, height, length, diameter, weight=1)
-    assert package.non_mechanizable_cost == result
-
-
-@pytest.mark.parametrize('width,height,length,result', [
-    (11, 10, 16, Decimal('0.00')),
-    (70, 10, 10, Decimal('0.00')),
-    (10, 70, 10, Decimal('0.00')),
-    (10, 10, 70, Decimal('0.00')),
-    (71, 10, 10, posting.NON_MECHANIZABLE_COST),
-    (10, 71, 10, posting.NON_MECHANIZABLE_COST),
-    (10, 10, 71, posting.NON_MECHANIZABLE_COST),
-])
-def test_non_mechanizable_additional_cost(width, height, length, result):
-    assert posting.Package.non_mechanizable_additional_cost(width, height, length) == result
+    assert package.is_mechanizable == result

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -596,3 +596,17 @@ def test_basic_freight_conversion():
     freight = posting.FreightResponse(SERVICE_SEDEX, 5, 10.00)
     assert freight.delivery_time == timedelta(days=5)
     assert freight.total == Decimal("10.00")
+
+
+@pytest.mark.parametrize('package,result', [
+    (posting.Package(posting.Package.TYPE_BOX, 11, 10, 16, weight=1), Decimal('0.00')),
+    (posting.Package(posting.Package.TYPE_BOX, 70, 10, 10, weight=1), Decimal('0.00')),
+    (posting.Package(posting.Package.TYPE_BOX, 10, 70, 10, weight=1), Decimal('0.00')),
+    (posting.Package(posting.Package.TYPE_BOX, 10, 10, 70, weight=1), Decimal('0.00')),
+    (posting.Package(posting.Package.TYPE_BOX, 71, 10, 10, weight=1), posting.NON_MECHANIZABLE_COST),
+    (posting.Package(posting.Package.TYPE_BOX, 10, 71, 10, weight=1), posting.NON_MECHANIZABLE_COST),
+    (posting.Package(posting.Package.TYPE_BOX, 10, 10, 71, weight=1), posting.NON_MECHANIZABLE_COST),
+    (posting.Package(posting.Package.TYPE_CYLINDER, 0, 0, 14, 2, weight=1), posting.NON_MECHANIZABLE_COST),
+])
+def test_non_mechanizable_cost(package, result):
+    assert package.non_mechanizable_cost == result

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -598,15 +598,29 @@ def test_basic_freight_conversion():
     assert freight.total == Decimal("10.00")
 
 
-@pytest.mark.parametrize('package,result', [
-    (posting.Package(posting.Package.TYPE_BOX, 11, 10, 16, weight=1), Decimal('0.00')),
-    (posting.Package(posting.Package.TYPE_BOX, 70, 10, 10, weight=1), Decimal('0.00')),
-    (posting.Package(posting.Package.TYPE_BOX, 10, 70, 10, weight=1), Decimal('0.00')),
-    (posting.Package(posting.Package.TYPE_BOX, 10, 10, 70, weight=1), Decimal('0.00')),
-    (posting.Package(posting.Package.TYPE_BOX, 71, 10, 10, weight=1), posting.NON_MECHANIZABLE_COST),
-    (posting.Package(posting.Package.TYPE_BOX, 10, 71, 10, weight=1), posting.NON_MECHANIZABLE_COST),
-    (posting.Package(posting.Package.TYPE_BOX, 10, 10, 71, weight=1), posting.NON_MECHANIZABLE_COST),
-    (posting.Package(posting.Package.TYPE_CYLINDER, 0, 0, 14, 2, weight=1), posting.NON_MECHANIZABLE_COST),
+@pytest.mark.parametrize('package_type,width,height,length,diameter,result', [
+    (posting.Package.TYPE_BOX, 11, 10, 16, 0, Decimal('0.00')),
+    (posting.Package.TYPE_BOX, 70, 10, 10, 0, Decimal('0.00')),
+    (posting.Package.TYPE_BOX, 10, 70, 10, 0, Decimal('0.00')),
+    (posting.Package.TYPE_BOX, 10, 10, 70, 0, Decimal('0.00')),
+    (posting.Package.TYPE_BOX, 71, 10, 10, 0, posting.NON_MECHANIZABLE_COST),
+    (posting.Package.TYPE_BOX, 10, 71, 10, 0, posting.NON_MECHANIZABLE_COST),
+    (posting.Package.TYPE_BOX, 10, 10, 71, 0, posting.NON_MECHANIZABLE_COST),
+    (posting.Package.TYPE_CYLINDER, 0, 0, 14, 2, posting.NON_MECHANIZABLE_COST),
 ])
-def test_non_mechanizable_cost(package, result):
+def test_non_mechanizable_cost(package_type, width, height, length, diameter, result):
+    package = posting.Package(package_type, width, height, length, diameter, weight=1)
     assert package.non_mechanizable_cost == result
+
+
+@pytest.mark.parametrize('width,height,length,result', [
+    (11, 10, 16, Decimal('0.00')),
+    (70, 10, 10, Decimal('0.00')),
+    (10, 70, 10, Decimal('0.00')),
+    (10, 10, 70, Decimal('0.00')),
+    (71, 10, 10, posting.NON_MECHANIZABLE_COST),
+    (10, 71, 10, posting.NON_MECHANIZABLE_COST),
+    (10, 10, 71, posting.NON_MECHANIZABLE_COST),
+])
+def test_non_mechanizable_additional_cost(width, height, length, result):
+    assert posting.Package.non_mechanizable_additional_cost(width, height, length) == result


### PR DESCRIPTION
Starting 05/02 Correios will create a new package's extra cost. If the package is a cylinder or any dimension surpass 70 cm, will be an additional cost of R$ 20.00.

This PR add a method to verify if the package is mechanizable or not.

Correios explanation below:
[Carta 16.pdf](https://github.com/olist/correios/files/1960356/Carta.16.pdf)