### PR TITLE
Add non mechanizable cost to package

### DIFF
--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -42,8 +42,11 @@ TRACKING_CODE_SIZE = 13
 TRACKING_CODE_NUMBER_SIZE = 8
 TRACKING_CODE_PREFIX_SIZE = 2
 TRACKING_CODE_SUFFIX_SIZE = 2
+
 IATA_COEFICIENT = 6.0
+
 VOLUMETRIC_WEIGHT_THRESHOLD = 10000  # g
+
 MIN_WIDTH, MAX_WIDTH = 11, 105  # cm
 MIN_HEIGHT, MAX_HEIGHT = 2, 105  # cm
 MIN_LENGTH, MAX_LENGTH = 16, 105  # cm
@@ -51,7 +54,9 @@ MIN_DIAMETER, MAX_DIAMETER = 5, 91  # cm
 MIN_CYLINDER_LENGTH, MAX_CYLINDER_LENGTH = 18, 105  # cm
 MIN_SIZE, MAX_SIZE = 29, 200  # cm
 MIN_CYLINDER_SIZE, MAX_CYLINDER_SIZE = 28, 200  # cm
+
 MAX_MECHANIZABLE_PACKAGE_SIZE = 70  # cm
+NON_MECHANIZABLE_COST = Decimal('20.0')
 
 
 INSURANCE_VALUE_THRESHOLDS = {
@@ -381,6 +386,10 @@ class Package:
         if self.package_type == Package.TYPE_CYLINDER:
             return False
         return max(self.width, self.height, self.length) <= MAX_MECHANIZABLE_PACKAGE_SIZE
+
+    @property
+    def non_mechanizable_cost(self):
+        return Decimal('0.0') if self.is_mechanizable else NON_MECHANIZABLE_COST
 
     @classmethod
     def calculate_volumetric_weight(cls, width, height, length) -> int:

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -611,3 +611,18 @@ def test_basic_freight_conversion():
 def test_package_is_mechanizable(package_type, width, height, length, diameter, result):
     package = posting.Package(package_type, width, height, length, diameter, weight=1)
     assert package.is_mechanizable == result
+
+
+@pytest.mark.parametrize('package_type,width,height,length,diameter,cost', [
+    (posting.Package.TYPE_BOX, 11, 10, 16, 0, 0),
+    (posting.Package.TYPE_BOX, 70, 10, 10, 0, 0),
+    (posting.Package.TYPE_BOX, 10, 70, 10, 0, 0),
+    (posting.Package.TYPE_BOX, 10, 10, 70, 0, 0),
+    (posting.Package.TYPE_BOX, 71, 10, 10, 0, posting.NON_MECHANIZABLE_COST),
+    (posting.Package.TYPE_BOX, 10, 71, 10, 0, posting.NON_MECHANIZABLE_COST),
+    (posting.Package.TYPE_BOX, 10, 10, 71, 0, posting.NON_MECHANIZABLE_COST),
+    (posting.Package.TYPE_CYLINDER, 0, 0, 14, 2, posting.NON_MECHANIZABLE_COST),
+])
+def test_package_non_mechanizable_cost(package_type, width, height, length, diameter, cost):
+    package = posting.Package(package_type, width, height, length, diameter, weight=1)
+    assert package.non_mechanizable_cost == cost


### PR DESCRIPTION
Some time ago correios changed how freight costs for "non mechanizable" packages [1] and we've already a property to determine whether a package is mechanizable (`Package.is_mechanizable`). This PR goes further and add a property to calculate its cost.

[1] https://www.correios.com.br/a-a-z/limites-de-dimensoes-e-peso