### PR TITLE
Pin backwards incompatible lib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ hubarcode
 
 # api
 requests
-zeep
+zeep==2.5.0
 lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ hubarcode
 
 # api
 requests
-zeep==2.5.0
+zeep==2.5.0  # the new version is incompatible with the current code
 lxml


### PR DESCRIPTION
A última atualização da lib zeep [1] quebrou os testes da lib correios. Pinnei enquanto o código não for atualizado para ser compatível com a nova versão da lib.

[1] https://github.com/mvantellingen/python-zeep/blob/master/CHANGES