### PR TITLE
Fix vcr to remove credentials before writing cassettes to file

### DIFF
--- a/tests/test_vcr.py
+++ b/tests/test_vcr.py
@@ -1,0 +1,41 @@
+from unittest import mock
+
+import pytest
+
+from .vcr import replace_auth, vcr
+
+
+@pytest.fixture
+def username():
+    return 'cuca'
+
+
+@pytest.fixture
+def password():
+    return 'beludo'
+
+
+@pytest.fixture
+def request_body(username, password):
+    body = (
+        "<?xml version=''1.0'' encoding=''utf-8''?>"
+        '<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">'
+        '<soap-env:Body><ns0:buscaEventosLista xmlns:ns0="http://resource.webservice.correios.com.br/">'
+        "<usuario>{}</usuario><senha>{}senha><tipo>L</tipo><resultado>T</resultado><lingua>101</lingua>"
+        "<objetos>JB683971943BR</objetos><objetos>JT365572014BR</objetos>"
+        "</ns0:buscaEventosLista></soap-env:Body></soap-env:Envelope>"""
+    )
+    body = body.format(username, password)
+    return body.encode()
+
+
+def test_replace_auth(request_body, username, password):
+    request = mock.Mock(body=request_body)
+    body = str(replace_auth(request))
+
+    assert username not in body
+    assert password not in body
+
+
+def test_vcr_uses_replace_auth():
+    assert vcr.before_record_request == replace_auth

--- a/tests/vcr.py
+++ b/tests/vcr.py
@@ -14,16 +14,32 @@
 
 
 import os
+import re
 
 from vcr import VCR
 
-FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+USER_REGEX = re.compile('<usuario>\w+</usuario>')
+PASS_REGEX = re.compile('<senha>.*</senha>')
 
+
+def replace_auth(request):
+    if not request.body:
+        return request
+
+    body = request.body.decode()
+    body = USER_REGEX.sub(r'<usuario>teste</usuario>', body)
+    body = PASS_REGEX.sub(r'<senha>****</senha>', body)
+    request.body = body.encode()
+    return request
+
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
 
 vcr = VCR(
     record_mode='once',
     serializer='yaml',
     cassette_library_dir=os.path.join(FIXTURES_DIR, 'cassettes'),
     path_transformer=VCR.ensure_suffix('.yaml'),
-    match_on=['method']
+    match_on=['method'],
+    before_record_request=replace_auth,
 )


### PR DESCRIPTION
This PR makes easier the re-creation of cassettes and, more importantly, prevents contributors from committing their correios' username and password.