### PR TITLE
Add lost tracking event

### DIFF
--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -1749,6 +1749,24 @@ TRACKING_STATUS = {
         '',
         'Acompanhar',
     ),
+    ('BDE', 80): (
+        'lost',
+        'Objeto extraviado',
+        '',
+        'Acionar a CAC dos Correios',
+    ),
+    ('BDI', 80): (
+        'lost',
+        'Objeto extraviado',
+        '',
+        'Acionar a CAC dos Correios',
+    ),
+    ('BDR', 80): (
+        'lost',
+        'Objeto extraviado',
+        '',
+        'Acionar a CAC dos Correios',
+    ),
 }
 
 ZIP_CODE_MAP = {

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -687,6 +687,9 @@ def test_basic_not_found_tracking_event():
     ("RO", 0),
     ("TRI", 0),
     # ("CMR", 0),
+    ("BDE", 80),
+    ("BDI", 80),
+    ("BDR", 80),
 ])
 def test_basic_event_status(status_type, status_number):
     event_status = posting.EventStatus(status_type, status_number)


### PR DESCRIPTION
According to correios tracking docs [1] we were missing the tracking event BD[EIR] 80 for lost packages. This PR adds it. 

[1] page 19 on https://www.correios.com.br/a-a-z/pdf/rastreamento-de-objetos/manual_rastreamentoobjetosws.pdf