### PR TITLE
Change "Valor Declarado" code

### DIFF
--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -257,14 +257,14 @@ TRACKING_PREFIX = {
 EXTRA_SERVICES = {
     1: {'code': "AR", 'name': "Aviso de Recebimento", 'display_on_label': True},
     2: {'code': "MP", 'name': "Mão Própria Nacional", 'display_on_label': True},
-    19: {'code': "VD", 'name': "Valor Declarado (Encomendas)", 'display_on_label': True},
     25: {'code': "RR", 'name': "Registro Nacional", 'display_on_label': False},
+    64: {'code': "VD", 'name': "Valor Declarado (Encomendas)", 'display_on_label': True},
 }
 
 EXTRA_SERVICE_AR = 1
 EXTRA_SERVICE_MP = 2
-EXTRA_SERVICE_VD = 19
 EXTRA_SERVICE_RR = 25
+EXTRA_SERVICE_VD = 64
 
 SERVICES = {
     '40215': {

--- a/documentation/modelo.xml
+++ b/documentation/modelo.xml
@@ -100,9 +100,10 @@
 			<valor_a_cobrar>0,0</valor_a_cobrar>
 		</nacional>
 		<servico_adicional>
-			<codigo_servico_adicional>025</codigo_servico_adicional>
 			<codigo_servico_adicional>001</codigo_servico_adicional>
-			<codigo_servico_adicional>019</codigo_servico_adicional>
+			<codigo_servico_adicional>002</codigo_servico_adicional>
+			<codigo_servico_adicional>025</codigo_servico_adicional>
+			<codigo_servico_adicional>064</codigo_servico_adicional>
 			<valor_declarado>99,00</valor_declarado>
 		</servico_adicional>
 		<dimensao_objeto>

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -394,7 +394,7 @@ def test_posting_list_serialization(posting_list, shipping_label):
     serializer.validate(document)
     xml = serializer.get_xml(document)
     assert xml.startswith(b'<?xml version="1.0" encoding="ISO-8859-1"?><correioslog>')
-    assert b"<codigo_servico_adicional>019</codigo_servico_adicional>" not in xml
+    assert b"<codigo_servico_adicional>064</codigo_servico_adicional>" not in xml
     assert b"<valor_declarado>10,29</valor_declarado>" not in xml
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -419,7 +419,7 @@ def test_declared_value(posting_list, shipping_label):
     serializer.validate(document)
     xml = serializer.get_xml(document)
     assert shipping_label.service == Service.get(SERVICE_PAC)
-    assert b"<codigo_servico_adicional>019</codigo_servico_adicional>" in xml
+    assert b"<codigo_servico_adicional>064</codigo_servico_adicional>" in xml
     assert b"<valor_declarado>18,50</valor_declarado>" in xml
 
 

--- a/tests/test_user_models.py
+++ b/tests/test_user_models.py
@@ -296,8 +296,8 @@ def test_fail_get_unknown_service():
 @pytest.mark.parametrize("number,extra_service_code", (
     (1, "AR"),
     (2, "MP"),
-    (19, "VD"),
     (25, "RR"),
+    (64, "VD"),
     (ExtraService.get(EXTRA_SERVICE_AR), "AR"),
 ))
 def test_extra_service_getter(number, extra_service_code):

--- a/tests/test_user_models.py
+++ b/tests/test_user_models.py
@@ -288,9 +288,10 @@ def test_fail_extra_service_invalid_data(number, code, name):
         ExtraService(number, code, name)
 
 
-def test_fail_get_unknown_service():
+@pytest.mark.parametrize('invalid_code', (0, 19))
+def test_fail_get_unknown_service(invalid_code):
     with pytest.raises(KeyError):
-        ExtraService.get(0)
+        ExtraService.get(invalid_code)
 
 
 @pytest.mark.parametrize("number,extra_service_code", (


### PR DESCRIPTION
On August first Correios changed the "Valor Declarado" code from `019` to `064`. Starting August 10 they will stop accepting PLPs or tags using the old code.