### PR TITLE
[DFQ] Add model PostalObject

### DIFF
--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -543,6 +543,72 @@ class Receipt:
         )
 
 
+class PostalObject:
+    def __init__(self,
+                 package: Package,
+                 declared_value: Union[int, float, Decimal],
+                 service: Union[Service, str, int]) -> None:
+        self.package = package
+        self.declared_value = declared_value
+        self.service = Service.get(service)
+
+        self._validate()
+
+    def _validate(self) -> None:
+        self._validate_package_weight()
+
+    def _validate_package_weight(self) -> None:
+        if self.service.max_weight is None:
+            return
+
+        if self.package.weight > self.service.max_weight:
+            message = "Max weight exceeded for service {!r}: {!r}g (max. {!r}g)".format(
+                self.package.weight,
+                str(self.service),
+                self.service.max_weight,
+            )
+            raise exceptions.InvalidMaxPackageWeightError(message)
+
+    @property
+    def additional_costs(self) -> Decimal:
+        return PostalObject.calculate_additional_costs(self.package, self.declared_value, self.service)
+
+    @property
+    def non_mechanizable_cost(self) -> Decimal:
+        return PostalObject.calculate_non_mechanizable_cost(self.package)
+
+    @property
+    def insurance_cost(self) -> Decimal:
+        return PostalObject.calculate_insurance_cost(self.declared_value, self.service)
+
+    @classmethod
+    def calculate_additional_costs(cls,
+                                   package: Package,
+                                   declared_value: Union[int, float, Decimal],
+                                   service: Union[Service, str, int]) -> Decimal:
+        non_mechanizable_cost = PostalObject.calculate_non_mechanizable_cost(package)
+        insurance_cost = PostalObject.calculate_insurance(declared_value, service)
+        return non_mechanizable_cost + insurance_cost
+
+    @classmethod
+    def calculate_non_mechanizable_cost(cls, package: Package) -> Decimal:
+        return Decimal('0.0') if package.is_mechanizable else NON_MECHANIZABLE_COST
+
+    @classmethod
+    def calculate_insurance_cost(cls,
+                                 declared_value: Union[int, float, Decimal],
+                                 service: Union[Service, str, int]) -> Decimal:
+        value = Decimal("0.00")
+        declared_value = Decimal(declared_value)
+        service_code = Service.get(service).code
+        insurance_value_threshold = INSURANCE_VALUE_THRESHOLDS.get(service_code, declared_value)
+
+        if declared_value > insurance_value_threshold:
+            value = (declared_value - insurance_value_threshold) * INSURANCE_PERCENTUAL_COST
+
+        return value
+
+
 class ShippingLabel:
     variable_data_identifier = 51  # Variable data identifier for package
     invoice_template = "{!s}"

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -587,7 +587,7 @@ class PostalObject:
                                    declared_value: Union[int, float, Decimal],
                                    service: Union[Service, str, int]) -> Decimal:
         non_mechanizable_cost = PostalObject.calculate_non_mechanizable_cost(package)
-        insurance_cost = PostalObject.calculate_insurance(declared_value, service)
+        insurance_cost = PostalObject.calculate_insurance_cost(declared_value, service)
         return non_mechanizable_cost + insurance_cost
 
     @classmethod
@@ -606,7 +606,7 @@ class PostalObject:
         if declared_value > insurance_value_threshold:
             value = (declared_value - insurance_value_threshold) * INSURANCE_PERCENTUAL_COST
 
-        return value
+        return to_decimal(value)
 
 
 class ShippingLabel:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from correios.models.address import Address, ReceiverAddress, SenderAddress
 from correios.models.data import TRACKING_PREFIX
 from correios.models.posting import (
     Package,
+    PostalObject,
     PostalUnit,
     PostInfo,
     PostingList,
@@ -192,6 +193,23 @@ class ReceiptFactory(Factory):
 
 
 register(ReceiptFactory, 'receipt')
+
+
+class PostalObjectFactory(Factory):
+    class Meta:
+        model = PostalObject
+
+    package = SubFactory(PackageFactory)
+    declared_value = faker.Faker(
+        'pydecimal',
+        left_digits=2,
+        right_digits=2,
+        positive=True
+    )
+    service = LazyFunction(lambda: random.choice(_services))
+
+
+register(PostalObjectFactory, "postal_object")
 
 
 class ShippingLabelFactory(Factory):

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -814,7 +814,9 @@ def test_postal_object_insurance_cost_property(mock_calculate_insurance_cost, po
 
 @mock.patch('correios.models.posting.PostalObject.calculate_insurance_cost')
 @mock.patch('correios.models.posting.PostalObject.calculate_non_mechanizable_cost')
-def test_postal_object_calculate_additional_costs(mock_calculate_non_mechanizable_cost, mock_calculate_insurance_cost, postal_object):
+def test_postal_object_calculate_additional_costs(
+        mock_calculate_non_mechanizable_cost, mock_calculate_insurance_cost, postal_object
+):
     mock_calculate_non_mechanizable_cost.return_value = 10.0
     mock_calculate_insurance_cost.return_value = 5.0
     result = posting.PostalObject.calculate_additional_costs(


### PR DESCRIPTION
The idea is to add a new abstraction: postal object. Postal object corresponds to a package registered to be sent by a carrier service.

This PR just adds this model without breaking the library's retrocompatibility. A next PR will do the following:
- remove 'service' from Package
- remove 'non_mechanizable_cost' and 'calculate_insurance' from Package
- modify ShippingLabel so it now has only a PostalObject, not a Package and a Service


This PR was coded along with @lamenezes