### PR TITLE
Update the minimum value of the declared value

### DIFF
--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -279,7 +279,7 @@ SERVICES = {
         'display_name': 'SEDEX 10',
         'symbol': "premium",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '81019': {
@@ -290,7 +290,7 @@ SERVICES = {
         'display_name': 'E-SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '41068': {
@@ -301,7 +301,7 @@ SERVICES = {
         'max_weight': 30000,
         'symbol': "standard",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("3000.00"),
     },
     '04669': {
@@ -312,7 +312,7 @@ SERVICES = {
         'max_weight': 30000,
         'symbol': "standard",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("3000.00"),
     },
     '40444': {
@@ -323,7 +323,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '40436': {
@@ -334,7 +334,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '40096': {
@@ -345,7 +345,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '04162': {
@@ -356,7 +356,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '40380': {
@@ -367,7 +367,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '40010': {
@@ -378,7 +378,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '41211': {
@@ -389,7 +389,7 @@ SERVICES = {
         'max_weight': 30000,
         'symbol': "standard",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("3000.00"),
     },
     '40630': {
@@ -400,7 +400,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '40916': {
@@ -411,7 +411,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '40908': {
@@ -422,7 +422,7 @@ SERVICES = {
         'display_name': 'SEDEX',
         'symbol': "express",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '41300': {
@@ -433,7 +433,7 @@ SERVICES = {
         'display_name': 'PAC',
         'symbol': "standard",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("3000.00"),
     },
     '40169': {
@@ -444,7 +444,7 @@ SERVICES = {
         'display_name': 'SEDEX 12',
         'symbol': "premium",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '40290': {
@@ -455,7 +455,7 @@ SERVICES = {
         'display_name': 'SEDEX Hoje',
         'symbol': "premium",
         'default_extra_services': [EXTRA_SERVICE_RR],
-        'min_declared_value': Decimal("18.50"),
+        'min_declared_value': Decimal("19.50"),
         'max_declared_value': Decimal("10000.00"),
     },
     '10154': {
@@ -489,8 +489,8 @@ SERVICE_SEDEX10 = '40215'
 SERVICE_SEDEX12 = '40169'
 SERVICE_E_SEDEX = '81019'
 
-INSURANCE_VALUE_THRESHOLD_PAC = Decimal("18.50")  # R$
-INSURANCE_VALUE_THRESHOLD_SEDEX = Decimal("18.50")  # R$
+INSURANCE_VALUE_THRESHOLD_PAC = Decimal("19.50")  # R$
+INSURANCE_VALUE_THRESHOLD_SEDEX = Decimal("19.50")  # R$
 INSURANCE_PERCENTUAL_COST = Decimal("0.01")  # 1%
 
 REGIONAL_DIRECTIONS = {

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -15,7 +15,7 @@
 import math
 from datetime import date, datetime, timedelta
 from decimal import Decimal
-from typing import Dict, List, Optional, Tuple, Union  # noqa: F401
+from typing import Dict, List, Optional, Tuple, Union, cast  # noqa: F401
 
 from PIL import Image
 
@@ -192,6 +192,7 @@ class TrackingCode:
     def create(cls, tracking_code: Union[str, 'TrackingCode']):
         if isinstance(tracking_code, cls):
             return tracking_code
+        tracking_code = cast(str, tracking_code)
         return cls(tracking_code)
 
     @classmethod

--- a/correios/models/user.py
+++ b/correios/models/user.py
@@ -15,7 +15,7 @@
 
 from datetime import datetime  # noqa: F401
 from decimal import Decimal
-from typing import Any, Dict, List, Optional, Sequence, Union  # noqa: F401
+from typing import Any, Dict, List, Optional, Sequence, Union, cast  # noqa: F401
 
 from PIL import Image
 
@@ -191,6 +191,7 @@ class Service:
     def get(cls, service: Union['Service', int, str]) -> 'Service':
         if isinstance(service, cls):
             return service
+        service = cast(Union[int, str], service)
         code = cls.sanitize_code(service)
         return cls(code=code, **SERVICES[code])
 
@@ -226,6 +227,7 @@ class ExtraService:
     def get(cls, number: Union['ExtraService', int]) -> 'ExtraService':
         if isinstance(number, cls):
             return number
+        number = cast(int, number)
         attrs = EXTRA_SERVICES[number]  # type: Dict[str, Any]
         return cls(number=number, **attrs)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -425,7 +425,7 @@ def test_declared_value(extra_service_vd, code, posting_list, shipping_label):
     xml = serializer.get_xml(document)
     assert shipping_label.service == Service.get(SERVICE_PAC)
     assert b'<codigo_servico_adicional>%b</codigo_servico_adicional>' % code in xml
-    assert b'<valor_declarado>18,50</valor_declarado>' in xml
+    assert b'<valor_declarado>19,50</valor_declarado>' in xml
 
 
 @pytest.mark.skipif(not correios, reason="API Client support disabled")

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -316,7 +316,7 @@ def test_shipping_label_with_min_declared_value_pac(posting_card, sender_address
         value=Decimal("0"),
         extra_services=[EXTRA_SERVICE_VD_PAC],
     )
-    assert shipping_label.value == Decimal("18.50")
+    assert shipping_label.value == Decimal("19.50")
 
 
 def test_shipping_label_with_min_declared_value_sedex(posting_card, sender_address, receiver_address, package):
@@ -331,7 +331,7 @@ def test_shipping_label_with_min_declared_value_sedex(posting_card, sender_addre
         value=Decimal("0"),
         extra_services=[EXTRA_SERVICE_VD_SEDEX],
     )
-    assert shipping_label.value == Decimal("18.50")
+    assert shipping_label.value == Decimal("19.50")
 
 
 def test_posted_shipping_label(

--- a/tests/vcr.py
+++ b/tests/vcr.py
@@ -18,8 +18,8 @@ import re
 
 from vcr import VCR
 
-USER_REGEX = re.compile('<usuario>\w+</usuario>')
-PASS_REGEX = re.compile('<senha>.*</senha>')
+USER_REGEX = re.compile(r'<usuario>\w+</usuario>')
+PASS_REGEX = re.compile(r'<senha>.*</senha>')
 
 
 def replace_auth(request):

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@ deps =
     -rrequirements-test.txt
 
 commands =
-    mypy correios --silent-imports
-    py.test --cov=correios
+    make cov-test
 
 [travis]
 3.5 = py35


### PR DESCRIPTION
The minimum declared value for all services has been updated by Correios. This PR update these values (currently 19.5[1]).

[1] - https://www.correios.com.br/para-voce/consultas-e-solicitacoes/precos-e-prazos/servicos-nacionais_pasta/carta