### PR TITLE
Handle fc 8

### DIFF
--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -1009,6 +1009,12 @@ TRACKING_STATUS = {
         '',
         'Acompanhar',
     ),
+    ('FC', 9): (
+        'delivery_unsuccessful',
+        'Remetente não retirou objeto na Unidade dos Correios',
+        '',
+        'Acompanhar',
+    ),
     ('LDE', 9): (
         'shipped',
         'Objeto saiu para entrega ao remetente',

--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -979,6 +979,12 @@ TRACKING_STATUS = {
         'Objeto será devolvido ao remetente',
         'Acompanhar o retorno do objeto ao remetente.',
     ),
+    ('FC', 8): (
+        'shipped',
+        'Área com distribuição sujeita a prazo diferenciado',
+        'Restrição de entrega domiciliar temporária',
+        'Acompanhar',
+    ),
     ('BDE', 9): (
         'lost',
         'Objeto não localizado',

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -88,7 +88,7 @@ class EventStatus:
         try:
             return TRACKING_STATUS[event_type, status_code]
         except KeyError:
-            raise exceptions.InvalidEventStatusError("{} is not valid".format(event_type))
+            raise exceptions.InvalidEventStatusError("{}/{} is not valid".format(event_type, status_code))
 
     @property
     def display_event_type(self):


### PR DESCRIPTION
The tracking event FC-08 seems to be undocumented, but I guess the mapping in this PR are safe to production.
This is en example of events where we could find this event (fc-08):
```
('delivered', 'Objeto entregue ao destinatário', 'Recebido por:', 'Finalizar a entrega. Não é mais necessário prosseguir com o acompanhamento.')
('shipped', 'Objeto saiu para entrega ao destinatário', '', 'Acompanhar')  
('shipped', 'Área com distribuição sujeita a prazo diferenciado', 'Restrição de entrega domiciliar temporária', 'Acompanhar')
('shipped', 'Objeto encaminhado para', '<nome da cidade>', 'Acompanhar')
('shipped', 'Objeto postado', '', 'Acompanhar')
```

Also, I could not find any tests for specific tracking events, so I left it as is.