### PR TITLE
Fix datamatrix generation cause for bad formating address complement

### DIFF
--- a/correios/models/address.py
+++ b/correios/models/address.py
@@ -276,6 +276,10 @@ class Address:
         self.longitude = longitude
 
     @property
+    def complement_safe_display(self) -> str:
+        return ''.join(c for c in str(self.complement) if c.isalnum())
+
+    @property
     def zip_code_display(self) -> str:
         return self.zip_code.display()
 

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -713,7 +713,7 @@ class ShippingLabel:
             "{!s:>05}".format(self.service.code),
             "{!s:>02}".format(self.posting_list_group),
             "{}".format(receiver_number),
-            "{!s:<20}".format(self.receiver.complement[:20]),
+            "{!s:<20}".format(self.receiver.complement_safe_display[:20].rjust(20, "0")),
             "{!s:>05}".format(0 if self.value is None else int(self.value * 100)),
             "{}".format(str(self.receiver.phone)[:12].rjust(12, "0") or "0" * 12),
             "{:+010.6f}".format(self.latitude),

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -288,6 +288,21 @@ def test_basic_default_shipping_label(posting_card, sender_address, receiver_add
     assert len(shipping_label.extra_services) == 1
 
 
+def test_shipping_label_get_datamatrix_info_with_compliment_display(
+    posting_card, sender_address, receiver_address, package
+):
+    receiver_address.complement = '15 • andar'
+    shipping_label = posting.ShippingLabel(
+        posting_card=posting_card,
+        sender=sender_address,
+        receiver=receiver_address,
+        service=4162,
+        package=package,
+        tracking_code="PD12345678 BR",
+    )
+    datamatrix = shipping_label.get_datamatrix_info()
+    assert '000000000000015andar' in datamatrix
+
 @pytest.mark.parametrize('extra_service_vd', (EXTRA_SERVICE_VD_PAC, EXTRA_SERVICE_VD_SEDEX))
 def test_shipping_label_with_declared_value(extra_service_vd, posting_card, sender_address, receiver_address, package):
     service = Service.get(SERVICE_SEDEX)

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -288,7 +288,7 @@ def test_basic_default_shipping_label(posting_card, sender_address, receiver_add
     assert len(shipping_label.extra_services) == 1
 
 
-def test_shipping_label_get_datamatrix_info_with_compliment_display(
+def test_shipping_label_get_datamatrix_info_with_complement_display(
     posting_card, sender_address, receiver_address, package
 ):
     receiver_address.complement = '15 • andar'

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -303,6 +303,7 @@ def test_shipping_label_get_datamatrix_info_with_compliment_display(
     datamatrix = shipping_label.get_datamatrix_info()
     assert '000000000000015andar' in datamatrix
 
+
 @pytest.mark.parametrize('extra_service_vd', (EXTRA_SERVICE_VD_PAC, EXTRA_SERVICE_VD_SEDEX))
 def test_shipping_label_with_declared_value(extra_service_vd, posting_card, sender_address, receiver_address, package):
     service = Service.get(SERVICE_SEDEX)


### PR DESCRIPTION
Corrige a geração da função de datamatrix que gera o código de barras.
O campo complement é muito permissivo, então faço com que na geração da datamatrix do código de barras ele considere apenas os algarismos alfanuméricos do complemento e ainda preenche o resto a esquerda com zeros, como fazem outros pedaços da damatrix.