### PR TITLE
Add new event type

### DIFF
--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -548,7 +548,7 @@ TRACKING_EVENT_TYPES = {
     "PO": "Postagem (exceção)",
     "RO": "Expedição de Lista de Registro",
     "TRI": "Triagem",
-    # "CMR": "Evento Desconhecido",  # event type not found in SRO documentation (issued on may, 2017)
+    "CMR": "Conferência de lista de registro",
 }
 
 TRACKING_STATUS = {
@@ -1782,6 +1782,12 @@ TRACKING_STATUS = {
         'Objeto extraviado',
         '',
         'Acionar a CAC dos Correios',
+    ),
+    ('CMR', 1): (
+        'shipped',
+        'Conferido',
+        '',
+        'Acompanhar',
     ),
 }
 

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -704,6 +704,7 @@ def test_basic_not_found_tracking_event():
     ("BDE", 80),
     ("BDI", 80),
     ("BDR", 80),
+    ("CMR", 1),
 ])
 def test_basic_event_status(status_type, status_number):
     event_status = posting.EventStatus(status_type, status_number)


### PR DESCRIPTION
We started to receive CMR as an event type and because of the error raised by the lib a few packages are not being correctly tracked.