### PR TITLE
Add mapping for BDR event, status=15

### DIFF
--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -1075,6 +1075,12 @@ TRACKING_STATUS = {
         'Endereço:',
         'Acompanhar. O interessado deverá buscar o objeto em uma Unidade dos Correios.',
     ),
+    ('BDR', 15): (
+        'shipped',
+        'Recebido na unidade de distribuição',
+        'Por determinação judicial o objeto será entregue em até 7 dias',
+        'Acompanhar',
+    ),
     ('PAR', 15): (
         'delivered',
         'Objeto recebido em <destino>',


### PR DESCRIPTION
Payload sample (redacted):
```
{
    'tipo': 'BDR',
    'status': '15',
    'data': '07/03/2019',
    'hora': '12:16',
    'descricao': 'Recebido na unidade de distribuição',
    'detalhe': 'Por determinação judicial o objeto será entregue em até 7 dias',
    'recebedor': None,
    # ...
```
It is quite similar to https://github.com/olist/correios/pull/142
