### PR TITLE
Add new tracking statuses

### DIFF
--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -661,6 +661,12 @@ TRACKING_STATUS = {
         'Objeto em análise de destinação',
         'Acompanhar',
     ),
+    ('BLQ', 2): (
+        'shipped',
+        'Tentativa de suspensão da entrega',
+        'Objeto em análise de destinação',
+        'Acompanhar',
+    ),
     ('CD', 1): (
         'shipped',
         'Objeto recebido na Unidade dos Correios',
@@ -1086,6 +1092,12 @@ TRACKING_STATUS = {
         'Objeto aguardando retirada no endereço indicado',
         'Endereço:',
         'Acompanhar. O interessado deverá buscar o objeto em uma Unidade dos Correios.',
+    ),
+    ('BDI', 14): (
+        'shipped',
+        'Desistência de postagem pelo remetente',
+        '',
+        'Acompanhar',
     ),
     ('BDR', 15): (
         'shipped',
@@ -1769,6 +1781,18 @@ TRACKING_STATUS = {
         'customs_control',
         'Revisão de tributo concluída - Tributo mantido',
         'Poderá haver incidência de juros e multa.',
+        'Acompanhar',
+    ),
+    ('BDR', 60): (
+        'shipped',
+        'O objeto encontra-se aguardando prazo para refugo',
+        '',
+        'Acompanhar',
+    ),
+    ('BDI', 60): (
+        'shipped',
+        'O objeto encontra-se aguardando prazo para refugo',
+        '',
         'Acompanhar',
     ),
     ('BDE', 66): (


### PR DESCRIPTION
We started to receive a few new tracking statuses from Correios.
They are not present in the documentation, so I tried to make an "educated guess" about them by looking at the response content and consulting a few in the Correios website.
All objects were shipped and those statuses seems to be non-terminative.

Redacted samples:
```
'tipo': 'BDI',
'status': '14',
'descricao': 'Desistência de postagem pelo remetente',
'detalhe': None,
```
```
'tipo': 'BLQ',
'status': '02',
'descricao': 'Tentativa de suspensão da entrega',
'detalhe': 'Objeto em análise de destinação',
```
```
'tipo': 'BDR',
'status': '60',
'descricao': 'O objeto encontra-se aguardando prazo para refugo',
'detalhe': None,
```
```
'tipo': 'BDI',
'status': '60',
'descricao': 'O objeto encontra-se aguardando prazo para refugo',
'detalhe': None,
```