### PR TITLE
Update python versions used in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,14 @@
+dist: xenial
+
 language: python
 
 cache: pip
 
 matrix:
     include:
-        - python: '3.5.1'
-        - python: '3.5.2'
-        - python: '3.5.3'
-        - python: '3.5.4'
-        - python: '3.5.5'
-        - python: '3.6.0'
-        - python: '3.6.1'
-        - python: '3.6.2'
-        - python: '3.6.3'
-        - python: '3.6.4'
-        - python: '3.6.5'
+        - python: '3.5.7'
+        - python: '3.6.8'
+        - python: '3.7.3'
 
 install:
   - make install

--- a/tox.ini
+++ b/tox.ini
@@ -9,3 +9,4 @@ commands =
 [travis]
 3.5 = py35
 3.6 = py36
+3.7 = py37


### PR DESCRIPTION
Update and reduce the number of patch versions used in the build process.
Add Python 3.7.