### PR TITLE
Remove incorrectly returned fields by Correios WS for each package type

### DIFF
--- a/correios/models/builders.py
+++ b/correios/models/builders.py
@@ -215,19 +215,32 @@ class ModelBuilder:
 
         return receiver_address
 
-    def _load_package(self, data) -> Package:
+    def _build_package_data(self, data):
         dimensions = data.dimensao_objeto
 
-        package = Package(
-            diameter=float(dimensions.dimensao_diametro.text.replace(",", ".")),
-            height=float(dimensions.dimensao_altura.text.replace(",", ".")),
-            length=float(dimensions.dimensao_comprimento.text.replace(",", ".")),
-            weight=float(data.peso.text.replace(",", ".")),
-            width=float(dimensions.dimensao_largura.text.replace(",", ".")),
-            package_type=dimensions.tipo_objeto,
-            service=data.codigo_servico_postagem.text,
-        )
+        if dimensions.tipo_objeto == Package.TYPE_BOX:
+            package_data = {
+                "height": dimensions.dimensao_altura.text,
+                "length": dimensions.dimensao_comprimento.text,
+                "weight": data.peso.text,
+                "width": dimensions.dimensao_largura.text,
+            }
+        elif dimensions.tipo_objeto == Package.TYPE_CYLINDER:
+            package_data = {
+                "diameter": dimensions.dimensao_diametro.text,
+                "length": dimensions.dimensao_comprimento.text,
+                "weight": data.peso.text,
+            }
+        else:
+            package_data = {"weight": data.peso.text}
 
+        package_data = {k: float(v.replace(",", ".")) for (k, v) in package_data.items()}
+        package_data["package_type"] = dimensions.tipo_objeto
+        return package_data
+
+    def _load_package(self, data) -> Package:
+        package_data = self._build_package_data(data)
+        package = Package(service=data.codigo_servico_postagem.text, **package_data)
         return package
 
     def build_posting_card_status(self, response):

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -55,4 +55,4 @@ def test_load_package_fields(model_builder, post_info_data, expected_fields, pac
 
     package_data = model_builder._build_package_data(post_info)
 
-    assert tuple(package_data.keys()) == expected_fields
+    assert set(package_data.keys()) == set(expected_fields)

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -1,0 +1,58 @@
+import pytest
+
+from correios.models.builders import ModelBuilder
+from correios.models.posting import Package
+from correios.xml_utils import fromstring
+
+
+@pytest.fixture
+def post_info_data():
+    return """
+      <objeto_postal>
+        <numero_etiqueta></numero_etiqueta>
+        <codigo_objeto_cliente></codigo_objeto_cliente>
+        <codigo_servico_postagem></codigo_servico_postagem>
+        <cubagem></cubagem>
+        <peso>2250</peso>
+        <rt1></rt1>
+        <rt2></rt2>
+        <destinatario></destinatario>
+        <nacional></nacional>
+        <servico_adicional>
+            <codigo_servico_adicional></codigo_servico_adicional>
+        </servico_adicional>
+        <dimensao_objeto>
+          <tipo_objeto>2</tipo_objeto>
+          <dimensao_altura>8.0</dimensao_altura>
+          <dimensao_largura>35.0</dimensao_largura>
+          <dimensao_comprimento>20.0</dimensao_comprimento>
+          <dimensao_diametro>5.0</dimensao_diametro>
+        </dimensao_objeto>
+        <data_postagem_sara></data_postagem_sara>
+        <status_processamento></status_processamento>
+        <numero_comprovante_postagem></numero_comprovante_postagem>
+        <valor_cobrado></valor_cobrado>
+      </objeto_postal>
+    """
+
+
+@pytest.fixture
+def model_builder():
+    return ModelBuilder()
+
+
+@pytest.mark.parametrize(
+    "expected_fields, package_type",
+    (
+        (("height", "length", "weight", "width", "package_type"), Package.TYPE_BOX),
+        (("diameter", "length", "weight", "package_type"), Package.TYPE_CYLINDER),
+        (("weight", "package_type"), Package.TYPE_ENVELOPE),
+    ),
+)
+def test_load_package_fields(model_builder, post_info_data, expected_fields, package_type):
+    post_info = fromstring(post_info_data)
+    post_info.dimensao_objeto.tipo_objeto = package_type
+
+    package_data = model_builder._build_package_data(post_info)
+
+    assert tuple(package_data.keys()) == expected_fields


### PR DESCRIPTION
Although a Package from the `BOX` type should not have any values for `diameter` we are receiving this when fetching PostInfos.
This causes an exception to be raised when validating the Package measures, and the user could not recover properly and treat this.
In order to make this method more functional, I'm filtering the measures fields that makes sense to each Package type prior to the instance creation.