### PR TITLE
Add validation on the Receipt builder

### DIFF
--- a/correios/models/builders.py
+++ b/correios/models/builders.py
@@ -14,7 +14,7 @@
 
 
 from datetime import datetime
-from typing import Dict
+from typing import Dict, Union
 
 from ..utils import to_decimal, to_integer
 from .address import ReceiverAddress, SenderAddress, ZipAddress
@@ -111,7 +111,7 @@ class ModelBuilder:
         )
         return post_info
 
-    def build_receipt(self, data):
+    def build_receipt(self, data) -> Union[None, Receipt]:
         if data.status_processamento == Receipt.STATUS_UNPROCESSED:
             return None
 

--- a/correios/models/builders.py
+++ b/correios/models/builders.py
@@ -14,7 +14,7 @@
 
 
 from datetime import datetime
-from typing import Dict, Union
+from typing import Dict, Optional
 
 from ..utils import to_decimal, to_integer
 from .address import ReceiverAddress, SenderAddress, ZipAddress
@@ -111,7 +111,7 @@ class ModelBuilder:
         )
         return post_info
 
-    def build_receipt(self, data) -> Union[None, Receipt]:
+    def build_receipt(self, data) -> Optional[Receipt]:
         if (data.status_processamento == Receipt.STATUS_UNPROCESSED or data.status_processamento == ""):
             return None
 

--- a/correios/models/builders.py
+++ b/correios/models/builders.py
@@ -111,7 +111,10 @@ class ModelBuilder:
         )
         return post_info
 
-    def build_receipt(self, data) -> Receipt:
+    def build_receipt(self, data):
+        if data.status_processamento == Receipt.STATUS_UNPROCESSED:
+            return None
+
         receipt = Receipt(
             number=data.numero_comprovante_postagem,
             post_date=data.data_postagem_sara.text,

--- a/correios/models/builders.py
+++ b/correios/models/builders.py
@@ -112,7 +112,7 @@ class ModelBuilder:
         return post_info
 
     def build_receipt(self, data) -> Union[None, Receipt]:
-        if data.status_processamento == Receipt.STATUS_UNPROCESSED:
+        if (data.status_processamento == Receipt.STATUS_UNPROCESSED or data.status_processamento == ""):
             return None
 
         receipt = Receipt(

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -492,6 +492,9 @@ class Package:
 
 
 class Receipt:
+    STATUS_UNPROCESSED = 0
+    STATUS_PROCESSED = 1
+
     def __init__(self, number: Union[int, str], post_date: Union[str, date], value: Union[str, Decimal]) -> None:
         self.number = int(number)
 

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -64,13 +64,14 @@ def test_build_receipt_when_status_processed(model_builder, post_info_data):
     receipt = model_builder.build_receipt(post_info)
     assert receipt is not None
     assert receipt.number == 155305650
-    assert receipt.real_value == '14.99'
-    assert receipt.real_post_date == '20190603'
+    assert receipt.real_value == "14.99"
+    assert receipt.real_post_date == "20190603"
 
 
-def test_build_receipt_when_status_unprocessed(model_builder, post_info_data):
+@pytest.mark.parametrize("status", ("", 0))
+def test_build_receipt_when_status_unprocessed(status, model_builder, post_info_data):
     post_info = fromstring(post_info_data)
-    post_info.status_processamento = 0
+    post_info.status_processamento = status
 
     receipt_data = model_builder.build_receipt(post_info)
     assert receipt_data is None

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -28,10 +28,10 @@ def post_info_data():
           <dimensao_comprimento>20.0</dimensao_comprimento>
           <dimensao_diametro>5.0</dimensao_diametro>
         </dimensao_objeto>
-        <data_postagem_sara></data_postagem_sara>
-        <status_processamento></status_processamento>
-        <numero_comprovante_postagem></numero_comprovante_postagem>
-        <valor_cobrado></valor_cobrado>
+        <data_postagem_sara>20190603</data_postagem_sara>
+        <status_processamento>1</status_processamento>
+        <numero_comprovante_postagem>155305650</numero_comprovante_postagem>
+        <valor_cobrado>14.99</valor_cobrado>
       </objeto_postal>
     """
 
@@ -56,3 +56,21 @@ def test_load_package_fields(model_builder, post_info_data, expected_fields, pac
     package_data = model_builder._build_package_data(post_info)
 
     assert set(package_data.keys()) == set(expected_fields)
+
+
+def test_build_receipt_when_status_processed(model_builder, post_info_data):
+    post_info = fromstring(post_info_data)
+
+    receipt = model_builder.build_receipt(post_info)
+    assert receipt is not None
+    assert receipt.number == 155305650
+    assert receipt.real_value == '14.99'
+    assert receipt.real_post_date == '20190603'
+
+
+def test_build_receipt_when_status_unprocessed(model_builder, post_info_data):
+    post_info = fromstring(post_info_data)
+    post_info.status_processamento = 0
+
+    receipt_data = model_builder.build_receipt(post_info)
+    assert receipt_data is None


### PR DESCRIPTION
Adiciona validação no builder do Receipt, para não criar o Receipt caso a posting list ainda não tenha sido processada. Pois os campos que são necessários para sua criação, só são inseridos quando a posting list é processada, o que acaba gerando o erro `TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'` [nesse ponto](https://github.com/olist/correios/blob/master/correios/models/posting.py#L496). Também geraria exception nos outros campos, só acaba estourando nesse primeiro cast.

Exemplo de como vem os campos quando a posting list ainda não foi processada:
```
<objeto_postal>
        <status_processamento>0</status_processamento>
        <data_postagem_sara />
        <numero_comprovante_postagem />
        <valor_cobrado />
</objeto_postal>
```  