### PR TITLE
Fix complement_safe_display ascii conversion

### DIFF
--- a/correios/models/address.py
+++ b/correios/models/address.py
@@ -17,6 +17,7 @@ import re
 import warnings
 from decimal import Decimal
 from typing import List, Tuple, Union
+import unicodedata
 
 from phonenumbers import NumberParseException, PhoneNumberFormat, format_number, parse
 
@@ -280,7 +281,8 @@ class Address:
 
     @property
     def complement_safe_display(self) -> str:
-        return "".join(c for c in str(self.complement) if c.isalnum())
+        complement = unicodedata.normalize("NFKD", self.complement).encode("ascii", "ignore").decode()
+        return " ".join(complement.split())
 
     @property
     def zip_code_display(self) -> str:

--- a/correios/models/address.py
+++ b/correios/models/address.py
@@ -14,10 +14,10 @@
 
 
 import re
+import unicodedata
 import warnings
 from decimal import Decimal
 from typing import List, Tuple, Union
-import unicodedata
 
 from phonenumbers import NumberParseException, PhoneNumberFormat, format_number, parse
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 black; python_version >= '3.6'
 factory-boy
-pytest
+pytest<5.0.0 #  https://github.com/pytest-dev/pytest-factoryboy/pull/78
 pytest-cov
 pytest-factoryboy
 tox

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -241,10 +241,11 @@ def test_basic_default_shipping_label(posting_card, sender_address, receiver_add
     assert len(shipping_label.extra_services) == 1
 
 
+@pytest.mark.parametrize("complement,expected", (("15 • andar", "15 andar"), ("ˆônibus", " onibus")))
 def test_shipping_label_get_datamatrix_info_with_complement_display(
-    posting_card, sender_address, receiver_address, package
+    posting_card, sender_address, receiver_address, package, complement, expected
 ):
-    receiver_address.complement = "15 • andar"
+    receiver_address.complement = complement
     shipping_label = posting.ShippingLabel(
         posting_card=posting_card,
         sender=sender_address,
@@ -254,7 +255,7 @@ def test_shipping_label_get_datamatrix_info_with_complement_display(
         tracking_code="PD12345678 BR",
     )
     datamatrix = shipping_label.get_datamatrix_info()
-    assert "000000000000015andar" in datamatrix
+    assert expected in datamatrix
 
 
 @pytest.mark.parametrize("extra_service_vd", (EXTRA_SERVICE_VD_PAC, EXTRA_SERVICE_VD_SEDEX))

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -241,7 +241,10 @@ def test_basic_default_shipping_label(posting_card, sender_address, receiver_add
     assert len(shipping_label.extra_services) == 1
 
 
-@pytest.mark.parametrize("complement,expected", (("15 • andar", "15 andar"), ("ˆônibus", "onibus")))
+@pytest.mark.parametrize(
+    "complement,expected",
+    (("15 • andar", "15 andar"), ("ˆônibus", "onibus"), ("many" + " " * 10 + "whitespaces", "many whitespaces")),
+)
 def test_shipping_label_get_datamatrix_info_with_complement_display(
     posting_card, sender_address, receiver_address, package, complement, expected
 ):

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -241,7 +241,7 @@ def test_basic_default_shipping_label(posting_card, sender_address, receiver_add
     assert len(shipping_label.extra_services) == 1
 
 
-@pytest.mark.parametrize("complement,expected", (("15 • andar", "15 andar"), ("ˆônibus", " onibus")))
+@pytest.mark.parametrize("complement,expected", (("15 • andar", "15 andar"), ("ˆônibus", "onibus")))
 def test_shipping_label_get_datamatrix_info_with_complement_display(
     posting_card, sender_address, receiver_address, package, complement, expected
 ):


### PR DESCRIPTION
Previous code didn't work for all cases of non-ascii characters in complement field.

This change also tries to replace accented characters with their ascii versions, and keeps the whitespaces since I couldn't find a reason to remove them.

*Pinned pytest version until pytest-factoryboy supports it's new version.