### PR TITLE
Fix build_receipt method

### DIFF
--- a/correios/models/builders.py
+++ b/correios/models/builders.py
@@ -112,7 +112,7 @@ class ModelBuilder:
         return post_info
 
     def build_receipt(self, data) -> Optional[Receipt]:
-        if (data.status_processamento == Receipt.STATUS_UNPROCESSED or data.status_processamento == ""):
+        if not data.status_processamento == Receipt.STATUS_PROCESSED:
             return None
 
         receipt = Receipt(

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -68,7 +68,7 @@ def test_build_receipt_when_status_processed(model_builder, post_info_data):
     assert receipt.real_post_date == "20190603"
 
 
-@pytest.mark.parametrize("status", ("", 0))
+@pytest.mark.parametrize("status", ("", 0, 2))
 def test_build_receipt_when_status_unprocessed(status, model_builder, post_info_data):
     post_info = fromstring(post_info_data)
     post_info.status_processamento = status


### PR DESCRIPTION
Previous code didn't work for all cases of build receipt and continues to raise the exception `TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType’`
because in addition to the `não processado` and `processado` status, there is a status `bloqueado` that is not in the manual. Because of this, I reversed the condition.

