### PR TITLE
[TINB-345] Update Python version matrix and pre-commit hooks

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,9 +1,0 @@
-[settings]
-line_length = 120
-known_first_party = correios
-multi_line_output = 3
-force_grid_wrap=0
-use_parenthesis=True
-include_trailing_comma=True
-atomic = true
-not_skip = __init__.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: git@github.com:pre-commit/pre-commit-hooks
-    rev: v2.2.1
+    rev: v2.4.0
     hooks:
     - id: debug-statements
     - id: trailing-whitespace
@@ -30,9 +30,16 @@ repos:
     types: [python]
 
 - repo: https://github.com/python/black
-  rev: 19.3b0
+  rev: 19.10b0
   hooks:
     - id: black
+
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: v4.3.21
+  hooks:
+    - id: isort
+      args: ['--check-only', '--diff']
+      additional_dependencies: ['toml']
 
 - repo: git@github.com:olist/hulks.git
   rev: 0.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ cache: pip
 
 matrix:
     include:
-        - python: '3.5.7'
-        - python: '3.6.8'
-        - python: '3.7.3'
+        - python: '3.5.9'
+        - python: '3.6.10'
+        - python: '3.7.6'
+        - python: '3.8.1'
 
 install:
   - make install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,3 @@ use_parentheses = true
 include_trailing_comma = true
 atomic = true
 not_skip = "__init__.py"
-sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
-default_section = "THIRDPARTY"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,15 @@
 [tool.black]
 line-length = 120
-target-version = ['py37']
+target-version = ["py37"]
+
+[tool.isort]
+line_length = 120
+known_first_party = "correios"
+multi_line_output = 3
+force_grid_wrap = 0
+use_parentheses = true
+include_trailing_comma = true
+atomic = true
+not_skip = "__init__.py"
+sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
+default_section = "THIRDPARTY"


### PR DESCRIPTION
Update Python version matrix used by Travis CI, update pre-commit hooks and add isort to them.