### PR TITLE
Send the original Fault as the cause of the ClosePostingListException

### DIFF
--- a/correios/client.py
+++ b/correios/client.py
@@ -207,7 +207,7 @@ class Correios:
             if str(exc).startswith("A PLP não será fechada"):
                 message = "Unable to close PLP. Tracking codes {} are already assigned to another PLP"
                 message = message.format(tracking_codes)
-                raise ClosePostingListError(message)
+                raise ClosePostingListError(message) from exc
             raise
 
         posting_list.close_with_id(id_)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,4 @@ use_parentheses = true
 include_trailing_comma = true
 atomic = true
 not_skip = "__init__.py"
+default_section = "THIRDPARTY"


### PR DESCRIPTION
We are receiving some strange posting list cases:

SIGEP Web accuses an error, but the posting list gets approved on SARA
Posting List is closed by SIGEP web but has rejected objects on SARA.

This PR sends the original error returned by SIGEP web to help us to evaluate those cases.

I did it by setting the exception's `__cause__`, since I think it has the least impact on the API.