### PR TITLE
[LOG1-782] -  Remove declared_value from xml

### DIFF
--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -260,6 +260,7 @@ EXTRA_SERVICES = {
     19: {"code": "VD", "name": "Valor Declarado (Encomendas)", "display_on_label": True},  # Sedex
     25: {"code": "RR", "name": "Registro Nacional", "display_on_label": False},
     64: {"code": "VD", "name": "Valor Declarado (Encomendas)", "display_on_label": True},  # PAC
+    65: {"code": "VD", "name": "Valor Declarado (Encomendas)", "display_on_label": True},  # PAC MINI
 }
 
 EXTRA_SERVICE_AR = 1
@@ -267,6 +268,7 @@ EXTRA_SERVICE_MP = 2
 EXTRA_SERVICE_VD_SEDEX = 19
 EXTRA_SERVICE_RR = 25
 EXTRA_SERVICE_VD_PAC = 64
+EXTRA_SERVICE_VD_PAC_MINI = 65
 EXTRA_SERVICE_VD = EXTRA_SERVICE_VD_SEDEX  # For backward compatibility
 
 

--- a/correios/models/user.py
+++ b/correios/models/user.py
@@ -29,7 +29,14 @@ from correios.exceptions import (
 )
 
 from ..utils import get_resource_path, to_datetime, to_integer
-from .data import EXTRA_SERVICE_VD_PAC, EXTRA_SERVICE_VD_SEDEX, EXTRA_SERVICES, REGIONAL_DIRECTIONS, SERVICES
+from .data import (
+    EXTRA_SERVICE_VD_PAC,
+    EXTRA_SERVICE_VD_PAC_MINI,
+    EXTRA_SERVICE_VD_SEDEX,
+    EXTRA_SERVICES,
+    REGIONAL_DIRECTIONS,
+    SERVICES,
+)
 
 EXTRA_SERVICE_CODE_SIZE = 2
 
@@ -220,7 +227,7 @@ class ExtraService:
         return self.number == other.number
 
     def is_declared_value(self):
-        return self in (EXTRA_SERVICE_VD_PAC, EXTRA_SERVICE_VD_SEDEX)
+        return self in (EXTRA_SERVICE_VD_PAC, EXTRA_SERVICE_VD_PAC_MINI, EXTRA_SERVICE_VD_SEDEX)
 
     @classmethod
     def get(cls, number: Union["ExtraService", int]) -> "ExtraService":

--- a/correios/serializers.py
+++ b/correios/serializers.py
@@ -98,7 +98,7 @@ class PostingListSerializer:
             xml_utils.SubElement(
                 extra_services, "codigo_servico_adicional", text="{:03d}".format(extra_service.number)
             )
-            if extra_service.number in {19, 64, 65}:
+            if extra_service.is_declared_value():
                 declared_value = str(shipping_label.value).replace(".", ",")
         xml_utils.SubElement(extra_services, "valor_declarado", text=declared_value)
 

--- a/correios/serializers.py
+++ b/correios/serializers.py
@@ -93,11 +93,14 @@ class PostingListSerializer:
         xml_utils.SubElement(national, "valor_a_cobrar", text=str(shipping_label.billing).replace(".", ","))
 
         extra_services = xml_utils.SubElement(item, "servico_adicional")
+        declared_value = "000,00"
         for extra_service in shipping_label.extra_services:
             xml_utils.SubElement(
                 extra_services, "codigo_servico_adicional", text="{:03d}".format(extra_service.number)
             )
-        xml_utils.SubElement(extra_services, "valor_declarado", text=str(shipping_label.value).replace(".", ","))
+            if extra_service.number in {19, 64, 65}:
+                declared_value = str(shipping_label.value).replace(".", ",")
+        xml_utils.SubElement(extra_services, "valor_declarado", text=declared_value)
 
         dimensions = xml_utils.SubElement(item, "dimensao_objeto")
         xml_utils.SubElement(dimensions, "tipo_objeto", text="{:03d}".format(shipping_label.package.package_type))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -389,7 +389,13 @@ def test_posting_list_serialization_with_crazy_utf8_character(posting_list, ship
 
 
 @pytest.mark.skipif(not correios, reason="API Client support disabled")
-@pytest.mark.parametrize("extra_service_vd,code", [(EXTRA_SERVICE_VD_PAC, b"064"), (EXTRA_SERVICE_VD_SEDEX, b"019")])
+@pytest.mark.parametrize(
+    "extra_service_vd,code",
+    [
+        (EXTRA_SERVICE_VD_PAC, b"064"),
+        (EXTRA_SERVICE_VD_SEDEX, b"019")
+    ]
+)
 def test_declared_value(extra_service_vd, code, posting_list, shipping_label):
     shipping_label.extra_services.append(ExtraService.get(extra_service_vd))
     shipping_label.real_value = 10.29
@@ -401,6 +407,22 @@ def test_declared_value(extra_service_vd, code, posting_list, shipping_label):
     assert shipping_label.service == Service.get(SERVICE_PAC)
     assert b"<codigo_servico_adicional>%b</codigo_servico_adicional>" % code in xml
     assert b"<valor_declarado>20,50</valor_declarado>" in xml
+    assert b"<valor_declarado>000,00</valor_declarado>" not in xml
+
+
+@pytest.mark.skipif(not correios, reason="API Client support disabled")
+def test_declared_value_without_insurance_extra_service(posting_list, shipping_label):
+    shipping_label.real_value = 10.29
+    posting_list.add_shipping_label(shipping_label)
+    serializer = PostingListSerializer()
+    document = serializer.get_document(posting_list)
+    serializer.validate(document)
+    xml = serializer.get_xml(document)
+    assert shipping_label.service == Service.get(SERVICE_PAC)
+    assert b"<codigo_servico_adicional>19</codigo_servico_adicional>" not in xml
+    assert b"<codigo_servico_adicional>64</codigo_servico_adicional>" not in xml
+    assert b"<codigo_servico_adicional>65</codigo_servico_adicional>" not in xml
+    assert b"<valor_declarado>000,00</valor_declarado>" in xml
 
 
 @pytest.mark.skipif(not correios, reason="API Client support disabled")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -36,6 +36,7 @@ from correios.models.data import (
     EXTRA_SERVICE_AR,
     EXTRA_SERVICE_MP,
     EXTRA_SERVICE_VD_PAC,
+    EXTRA_SERVICE_VD_PAC_MINI,
     EXTRA_SERVICE_VD_SEDEX,
     FREIGHT_ERROR_FINAL_ZIPCODE_RESTRICTED,
     FREIGHT_ERROR_INITIAL_AND_FINAL_ZIPCODE_RESTRICTED,
@@ -393,6 +394,7 @@ def test_posting_list_serialization_with_crazy_utf8_character(posting_list, ship
     "extra_service_vd,code",
     [
         (EXTRA_SERVICE_VD_PAC, b"064"),
+        (EXTRA_SERVICE_VD_PAC_MINI, b"065"),
         (EXTRA_SERVICE_VD_SEDEX, b"019")
     ]
 )

--- a/tests/test_user_models.py
+++ b/tests/test_user_models.py
@@ -284,10 +284,33 @@ def test_fail_get_unknown_service():
 
 @pytest.mark.parametrize(
     "number,extra_service_code",
-    ((1, "AR"), (2, "MP"), (25, "RR"), (19, "VD"), (64, "VD"), (ExtraService.get(EXTRA_SERVICE_AR), "AR")),
+    (
+        (1, "AR"),
+        (2, "MP"),
+        (25, "RR"),
+        (19, "VD"),
+        (64, "VD"),
+        (65, "VD"),
+        (ExtraService.get(EXTRA_SERVICE_AR), "AR")
+    ),
 )
 def test_extra_service_getter(number, extra_service_code):
     assert ExtraService.get(number).code == extra_service_code
+
+
+@pytest.mark.parametrize(
+    "number,code,description,is_declared_value",
+    (
+        (19, "VD", "Valor Declarado (Encomendas)", True),
+        (64, "VD", "Valor Declarado (Encomendas)", True),
+        (65, "VD", "Valor Declarado (Encomendas)", True),
+        (1, "AR", "Aviso de Recebimento", False),
+        (25, "RR", "Registro Nacional", False),
+    )
+)
+def test_extra_service_is_declared_value(number, code, description, is_declared_value):
+    extra_service = ExtraService(number, code, description)
+    assert extra_service.is_declared_value() == is_declared_value
 
 
 def test_basic_regional_direction():


### PR DESCRIPTION
**What**
Remove a tag `<valor_declarado></valor_declarado>` do xml enviado na contratação dos correios

**Why**
Hoje, todos os contratos possuem seguro, que na maiorias das vezes não é utilizado e gastamos dinheiro a toa.  Para remover a contratação, devemos zerar o valor da tag `<valor_declarado>` e eliminar as tags de serviço adicional com códigos 19, 64 ou 65.

`Story`: https://jira-olist.atlassian.net/browse/LOG1-755
`Task`: https://jira-olist.atlassian.net/browse/LOG1-782