### PR TITLE
Update minimum declared value for PAC and SEDEX to 20.50 BRL

### DIFF
--- a/correios/models/data.py
+++ b/correios/models/data.py
@@ -279,7 +279,7 @@ SERVICES = {
         "display_name": "SEDEX 10",
         "symbol": "premium",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("10000.00"),
     },
     "81019": {
@@ -290,7 +290,7 @@ SERVICES = {
         "display_name": "E-SEDEX",
         "symbol": "express",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("10000.00"),
     },
     "41068": {
@@ -301,7 +301,7 @@ SERVICES = {
         "max_weight": 30000,
         "symbol": "standard",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("3000.00"),
     },
     "04669": {
@@ -312,7 +312,7 @@ SERVICES = {
         "max_weight": 30000,
         "symbol": "standard",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("3000.00"),
     },
     "40444": {
@@ -323,7 +323,7 @@ SERVICES = {
         "display_name": "SEDEX",
         "symbol": "express",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("10000.00"),
     },
     "40436": {
@@ -334,7 +334,7 @@ SERVICES = {
         "display_name": "SEDEX",
         "symbol": "express",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("10000.00"),
     },
     "40096": {
@@ -345,7 +345,7 @@ SERVICES = {
         "display_name": "SEDEX",
         "symbol": "express",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("10000.00"),
     },
     "04162": {
@@ -356,7 +356,7 @@ SERVICES = {
         "display_name": "SEDEX",
         "symbol": "express",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("10000.00"),
     },
     "40380": {
@@ -367,7 +367,7 @@ SERVICES = {
         "display_name": "SEDEX",
         "symbol": "express",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("10000.00"),
     },
     "40010": {
@@ -378,7 +378,7 @@ SERVICES = {
         "display_name": "SEDEX",
         "symbol": "express",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("10000.00"),
     },
     "41211": {
@@ -389,7 +389,7 @@ SERVICES = {
         "max_weight": 30000,
         "symbol": "standard",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("3000.00"),
     },
     "40630": {
@@ -400,7 +400,7 @@ SERVICES = {
         "display_name": "SEDEX",
         "symbol": "express",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("10000.00"),
     },
     "04316": {
@@ -411,7 +411,7 @@ SERVICES = {
         "display_name": "SEDEX",
         "symbol": "express",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("10000.00"),
     },
     "40916": {
@@ -422,7 +422,7 @@ SERVICES = {
         "display_name": "SEDEX",
         "symbol": "express",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("10000.00"),
     },
     "40908": {
@@ -433,7 +433,7 @@ SERVICES = {
         "display_name": "SEDEX",
         "symbol": "express",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("10000.00"),
     },
     "41300": {
@@ -444,7 +444,7 @@ SERVICES = {
         "display_name": "PAC",
         "symbol": "standard",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("3000.00"),
     },
     "04812": {
@@ -455,7 +455,7 @@ SERVICES = {
         "max_weight": 30000,
         "symbol": "standard",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("3000.00"),
     },
     "40169": {
@@ -466,7 +466,7 @@ SERVICES = {
         "display_name": "SEDEX 12",
         "symbol": "premium",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("10000.00"),
     },
     "40290": {
@@ -477,7 +477,7 @@ SERVICES = {
         "display_name": "SEDEX Hoje",
         "symbol": "premium",
         "default_extra_services": [EXTRA_SERVICE_RR],
-        "min_declared_value": Decimal("19.50"),
+        "min_declared_value": Decimal("20.50"),
         "max_declared_value": Decimal("10000.00"),
     },
     "10154": {
@@ -514,8 +514,8 @@ SERVICE_SEDEX10 = "40215"
 SERVICE_SEDEX12 = "40169"
 SERVICE_E_SEDEX = "81019"
 
-INSURANCE_VALUE_THRESHOLD_PAC = Decimal("19.50")  # R$
-INSURANCE_VALUE_THRESHOLD_SEDEX = Decimal("19.50")  # R$
+INSURANCE_VALUE_THRESHOLD_PAC = Decimal("20.50")  # R$
+INSURANCE_VALUE_THRESHOLD_SEDEX = Decimal("20.50")  # R$
 INSURANCE_PERCENTUAL_COST = Decimal("0.01")  # 1%
 
 REGIONAL_DIRECTIONS = {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -400,7 +400,7 @@ def test_declared_value(extra_service_vd, code, posting_list, shipping_label):
     xml = serializer.get_xml(document)
     assert shipping_label.service == Service.get(SERVICE_PAC)
     assert b"<codigo_servico_adicional>%b</codigo_servico_adicional>" % code in xml
-    assert b"<valor_declarado>19,50</valor_declarado>" in xml
+    assert b"<valor_declarado>20,50</valor_declarado>" in xml
 
 
 @pytest.mark.skipif(not correios, reason="API Client support disabled")

--- a/tests/test_posting_models.py
+++ b/tests/test_posting_models.py
@@ -289,7 +289,7 @@ def test_shipping_label_with_min_declared_value_pac(posting_card, sender_address
         value=Decimal("0"),
         extra_services=[EXTRA_SERVICE_VD_PAC],
     )
-    assert shipping_label.value == Decimal("19.50")
+    assert shipping_label.value == Decimal("20.50")
 
 
 def test_shipping_label_with_min_declared_value_sedex(posting_card, sender_address, receiver_address, package):
@@ -304,7 +304,7 @@ def test_shipping_label_with_min_declared_value_sedex(posting_card, sender_addre
         value=Decimal("0"),
         extra_services=[EXTRA_SERVICE_VD_SEDEX],
     )
-    assert shipping_label.value == Decimal("19.50")
+    assert shipping_label.value == Decimal("20.50")
 
 
 def test_posted_shipping_label(posting_card, sender_address, receiver_address, package, receipt):


### PR DESCRIPTION
Correios readjusted the minimum declared value from 19.50 to 20.50.

This PR updates this value to every PAC and SEDEX service in this lib