### PR TITLE
Fix max_length on XML

### DIFF
--- a/correios/serializers.py
+++ b/correios/serializers.py
@@ -74,8 +74,8 @@ class PostingListSerializer:
         xml_utils.SubElement(address, "telefone_destinatario", cdata=receiver.phone.short)
         xml_utils.SubElement(address, "celular_destinatario", cdata=receiver.cellphone.short)
         xml_utils.SubElement(address, "email_destinatario", cdata=str(receiver.email))
-        xml_utils.SubElement(address, "logradouro_destinatario", cdata=str(receiver.street))
-        xml_utils.SubElement(address, "complemento_destinatario", cdata=str(receiver.complement))
+        xml_utils.SubElement(address, "logradouro_destinatario", cdata=str(receiver.street)[:50])
+        xml_utils.SubElement(address, "complemento_destinatario", cdata=str(receiver.complement)[:30])
         xml_utils.SubElement(address, "numero_end_destinatario", text=str(receiver.number))
 
         national = xml_utils.SubElement(item, "nacional")
@@ -95,9 +95,7 @@ class PostingListSerializer:
         extra_services = xml_utils.SubElement(item, "servico_adicional")
         declared_value = "000,00"
         for extra_service in shipping_label.extra_services:
-            xml_utils.SubElement(
-                extra_services, "codigo_servico_adicional", text="{:03d}".format(extra_service.number)
-            )
+            xml_utils.SubElement(extra_services, "codigo_servico_adicional", text="{:03d}".format(extra_service.number))
             if extra_service.is_declared_value():
                 declared_value = str(shipping_label.value).replace(".", ",")
         xml_utils.SubElement(extra_services, "valor_declarado", text=declared_value)

--- a/tests/test_user_models.py
+++ b/tests/test_user_models.py
@@ -284,15 +284,7 @@ def test_fail_get_unknown_service():
 
 @pytest.mark.parametrize(
     "number,extra_service_code",
-    (
-        (1, "AR"),
-        (2, "MP"),
-        (25, "RR"),
-        (19, "VD"),
-        (64, "VD"),
-        (65, "VD"),
-        (ExtraService.get(EXTRA_SERVICE_AR), "AR")
-    ),
+    ((1, "AR"), (2, "MP"), (25, "RR"), (19, "VD"), (64, "VD"), (65, "VD"), (ExtraService.get(EXTRA_SERVICE_AR), "AR")),
 )
 def test_extra_service_getter(number, extra_service_code):
     assert ExtraService.get(number).code == extra_service_code
@@ -306,7 +298,7 @@ def test_extra_service_getter(number, extra_service_code):
         (65, "VD", "Valor Declarado (Encomendas)", True),
         (1, "AR", "Aviso de Recebimento", False),
         (25, "RR", "Registro Nacional", False),
-    )
+    ),
 )
 def test_extra_service_is_declared_value(number, code, description, is_declared_value):
     extra_service = ExtraService(number, code, description)


### PR DESCRIPTION
Fix max_length on XML
The Renderization of XML is fetching the total size of the string. This PR prevent this long string based on max_lenght rule of field