### PR TITLE
Correção de bug em calculo de fretes

### DIFF
--- a/correios/client.py
+++ b/correios/client.py
@@ -260,7 +260,7 @@ class Correios:
             str(from_zip),
             str(to_zip),
             package.weight / KG,
-            package.package_type,
+            package.freight_package_type,
             package.length,
             package.height,
             package.width,


### PR DESCRIPTION
O cálculo do frete (calculate_freights) estava enviando o type de pacote da classe e não o tipo de pacote de envio.