### PR TITLE
Sanitize shipping label fields

### DIFF
--- a/correios/models/address.py
+++ b/correios/models/address.py
@@ -23,7 +23,7 @@ from phonenumbers import NumberParseException, PhoneNumberFormat, format_number,
 
 from correios.exceptions import InvalidStateError, InvalidZipCodeError
 from correios.models.data import ZIP_CODE_MAP, ZIP_CODES
-from correios.utils import capitalize_phrase, rreplace
+from correios.utils import capitalize_phrase, rreplace, sanitize_phrase
 
 ZIP_CODE_LENGTH = 8
 STATE_LENGTH = 2
@@ -280,8 +280,12 @@ class Address:
         self.longitude = longitude
 
     @property
+    def label_complement(self) -> str:
+        return sanitize_phrase(self.complement)
+
+    @property
     def complement_safe_display(self) -> str:
-        complement = unicodedata.normalize("NFKD", self.complement).encode("ascii", "ignore").decode()
+        complement = unicodedata.normalize("NFKD", self.label_complement).encode("ascii", "ignore").decode()
         return " ".join(complement.split())
 
     @property
@@ -292,7 +296,7 @@ class Address:
     def basic_address(self) -> str:
         number = self.number
         if self.complement:
-            number = "{} - {}".format(self.number, self.complement)
+            number = "{} - {}".format(self.number, self.label_complement)
 
         if self.neighborhood:
             return capitalize_phrase("{}, {}, {}".format(self.street, number, self.neighborhood))
@@ -311,7 +315,7 @@ class Address:
 
     @property
     def label_name(self) -> str:
-        return capitalize_phrase(self.name)
+        return capitalize_phrase(sanitize_phrase(self.name))
 
     @property
     def display_address(self) -> Tuple[str, str]:
@@ -330,6 +334,10 @@ class Address:
     @property
     def zip_complement(self) -> str:
         return self.filtered_number or "0"
+
+    @property
+    def label_city(self) -> str:
+        return sanitize_phrase(self.city)
 
 
 class ReceiverAddress(Address):

--- a/correios/models/posting.py
+++ b/correios/models/posting.py
@@ -555,13 +555,13 @@ class ShippingLabel:
     receiver_data_template = (
         "{receiver.label_name!s:>.50}<br/>"
         "{receiver.label_address!s:>.95}<br/>"
-        "<b>{receiver.zip_code_display}</b> {receiver.city}/{receiver.state}"
+        "<b>{receiver.zip_code_display}</b> {receiver.label_city}/{receiver.state}"
     )
 
     sender_data_template = (
         "<b>Remetente:</b> {sender.label_name!s:>.40}<br/>"
         "{sender.label_address!s:>.95}<br/>"
-        "<b>{sender.zip_code_display}</b> {sender.city}-{sender.state}"
+        "<b>{sender.zip_code_display}</b> {sender.label_city}-{sender.state}"
     )
 
     def __init__(

--- a/correios/utils.py
+++ b/correios/utils.py
@@ -104,3 +104,7 @@ def get_resource_path(path) -> Path:
     resource_package = "correios"
     resource_path = os.path.join("data", path)
     return Path(pkg_resources.resource_filename(resource_package, resource_path))
+
+
+def sanitize_phrase(phrase: str) -> str:
+    return re.sub("[!@#$º><%&]", "", phrase)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,15 @@ from unittest import mock
 
 import pytest
 
-from correios.utils import RangeSet, capitalize_phrase, get_resource_path, rreplace, to_decimal, to_integer
+from correios.utils import (
+    RangeSet,
+    capitalize_phrase,
+    get_resource_path,
+    rreplace,
+    sanitize_phrase,
+    to_decimal,
+    to_integer,
+)
 
 phrase = "FOo bAr BAZ qux"
 
@@ -124,3 +132,11 @@ def test_should_use_pkg_resources_to_get_wsdl_files(mock_resource):
 
     mock_resource.assert_called_with("correios", "data/fake")
     assert str(path) == "/"
+
+
+@pytest.mark.parametrize(
+    "phrase, expected_phrase",
+    (("lord &%>º<of #the!$ rings", "lord of the rings"), ("bilbo!@#$º><%& bolseiro", "bilbo bolseiro"),),
+)
+def test_sanitize_phrase(phrase, expected_phrase):
+    assert sanitize_phrase(phrase) == expected_phrase


### PR DESCRIPTION
What
Sanitize fields on Shipping label removing especial characters `!@#$º><%&`

Why
Error on generating PLP because special characters on this labels.